### PR TITLE
Ignore .zeo/ so local seat identities cannot be committed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,3 +168,12 @@ temp/
 *.bak
 *.orig
 *.rej
+
+# ------------------------------------------------------------------------------
+# Local agent tooling
+# ------------------------------------------------------------------------------
+# Seat identities map a seat name to a real GitHub account and are per-machine.
+# They were protected only by a local .git/info/exclude, which does not travel:
+# a fresh clone of this public repository had nothing stopping `git add -A` from
+# committing someone's account names. It has already happened once here.
+.zeo/


### PR DESCRIPTION
Seat identities map a seat name to a **real GitHub account**, and were protected only by `.git/info/exclude` — which is per-clone and does not travel. A fresh clone of this public repository had nothing stopping `git add -A` from committing someone's account names.

Not hypothetical: it happened once during the dev6 migration here. Caught before the push, but only by inspection.

One line in `.gitignore`. Trivially revertible if you would rather keep this per-machine.