### PR TITLE
Ignore the rest of the seat overlay, not just .zeo/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -177,3 +177,11 @@ temp/
 # a fresh clone of this public repository had nothing stopping `git add -A` from
 # committing someone's account names. It has already happened once here.
 .zeo/
+
+# The rest of the ZEO seat overlay, for the same reason. These are per-machine
+# agent boot files, never repository content. .claude/, .codex/, .agents/ and
+# CLAUDE.md were already covered here; scripts/zeo-org, AGENTS.md and ZEO-BOOT.md
+# were left behind in .git/info/exclude, which is per-clone and does not travel.
+/scripts/zeo-org
+/AGENTS.md
+/ZEO-BOOT.md


### PR DESCRIPTION
## The gap

PR #12 moved `.zeo/` out of `.git/info/exclude` into the committed `.gitignore`,
for a good reason recorded in that file: `info/exclude` is per-clone and does not
travel, so a fresh clone of this public repo had nothing stopping `git add -A`
from committing real GitHub account names. That had already happened once.

Three files of the same overlay were left behind under the same broken protection:

| path | before | after |
|---|---|---|
| `scripts/zeo-org` | `.git/info/exclude` only | committed `.gitignore` |
| `AGENTS.md` | `.git/info/exclude` only | committed `.gitignore` |
| `ZEO-BOOT.md` | `.git/info/exclude` only | committed `.gitignore` |

`.claude/`, `.codex/`, `.agents/`, `CLAUDE.md` and `.zeo/` were already covered.

## Verified behaviourally, not by reading the file

Reset the index fully and ran `git add -A` — the exact accident that leaked
account names before. None of the eight overlay paths stage.

`make validate`: 97 tests, 18 checks, green.

## Note for reviewers

On this machine the agent-spec contract test ran rather than skipping (rasa-pro
resolvable via `.env`), so this run also exercised the `tool_timeout` drift
detector that `make validate` normally skips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YAKn2Fc6rATu6zDAb6Z4ya