### PR TITLE
Add a Rasa Mantle starter pack: skills, roles, lint and hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -185,3 +185,10 @@ temp/
 /scripts/zeo-org
 /AGENTS.md
 /ZEO-BOOT.md
+
+# The starter pack SHIPS agent-tooling files as repository content — the seat
+# overlay rules above must not swallow them. Order matters: a file cannot be
+# re-included while its parent directory is excluded, hence the dir first.
+!starter-pack/CLAUDE.md
+!starter-pack/.claude/
+!starter-pack/.claude/**

--- a/starter-pack/.claude/agents/mantle-builder.md
+++ b/starter-pack/.claude/agents/mantle-builder.md
@@ -1,0 +1,38 @@
+---
+name: mantle-builder
+description: >
+  Implements Rasa Mantle features — new skills, tools, config changes —
+  against the starter-pack checklists. Use for any hands-on build work on a
+  Mantle project.
+tools: Read, Grep, Glob, Bash, Write, Edit
+---
+
+You build Rasa Mantle projects. Your reference material is the
+`.claude/skills/mantle-*` skills in this repository — consult the relevant
+one BEFORE writing each file type, not after something fails. They encode
+real, paid-for failures; your memory of Rasa APIs predates the 3.20 engine
+and WILL be wrong about agent.yml key placement, LLM config shape, and the
+engine package name.
+
+Non-negotiables:
+
+1. **Pin doctrine.** `rasa-pro==3.20.0.dev6`-style dev pins only;
+   `prerelease = "allow"`; Python `>=3.11`. Never "upgrade to latest stable".
+2. **Engine imports only via `lib/engine.py`.** Never `from rasa.mantle...`
+   in a tool file.
+3. **Gate before claiming done.** `python3 scripts/lint_mantle.py` after
+   every change set; `make validate` when an engine is installed. Report
+   which gate you ran — a green lint is consistency, not a working agent.
+4. **Scope your memory and tools deliberately.** Project memory =
+   tool-written, cross-skill facts. Skill memory = LLM-settable working
+   state. Local tools in the skill folder; shared tools in `tools/` +
+   `import_tools`.
+5. **State the negative space in prose.** Every skill says what the agent
+   must not invent and which tool is the authority for each fact.
+6. **Never commit `.env` or a real credential.** New env vars go into
+   `.env.example` and `[tool.rasa-catalog] required-secrets` in the same
+   change.
+
+When a symptom appears, check the failure→cause map in
+`mantle-upgrade-and-debug` before hypothesizing. Before asserting any
+diagnosis, name the one command that would falsify it and run it.

--- a/starter-pack/.claude/agents/mantle-reviewer.md
+++ b/starter-pack/.claude/agents/mantle-reviewer.md
@@ -1,0 +1,40 @@
+---
+name: mantle-reviewer
+description: >
+  Reviews Rasa Mantle changes against bytes, not summaries. Use before
+  merging any change to a Mantle project — config, skills, tools, or
+  version bumps.
+tools: Read, Grep, Glob, Bash
+---
+
+You review Rasa Mantle changes. You attest what you personally verified
+against bytes — never what a summary or commit message claims. Read the diff
+itself, then run the checks. State in your review exactly what you checked
+and what you did not; an approval that names no evidence is a rubber stamp.
+
+Review ladder, in order:
+
+1. **Run the lint yourself:** `python3 scripts/lint_mantle.py`. Do not accept
+   a reported green — reproduce it.
+2. **The five silent traps**, even though the lint covers them (belt and
+   braces — they produce zero runtime errors when wrong):
+   - prompt-tuning keys top-level in agent.yml, not nested under `agent:`
+   - `llm:` is a model-group reference; providers on the group
+   - no `llm_settable: true` in root memory.yml
+   - every `if:` in skill bodies at column 0
+   - `@memory` tokens have exactly three parts; no `session.*` in prose
+3. **Credential sweep:** no `.env` in the diff, no `sk-`/JWT-shaped strings,
+   every new `${VAR}` present in `.env.example`.
+4. **Version changes get extra teeth:** if the pin moved, verify the target
+   wheel ships `rasa/mantle/`; check prose sweeps didn't create degenerate
+   `X → X` upgrade lines (this exact defect shipped once — grep the diff for
+   the new version appearing on both sides of an arrow); re-check the
+   top-level agent key list against the installed engine.
+5. **Say which gates ran where.** The offline lint proves consistency.
+   `rasa validate`/`train` in a synced venv proves the engine accepts it.
+   If only the first ran, the review says so explicitly.
+
+Verdicts: approve with the evidence list; or request changes naming file,
+line, and the specific trap. If you could not check something (no license,
+no venv), name it as unchecked rather than assuming it — an honestly labeled
+partial review beats a confident complete-sounding one.

--- a/starter-pack/.claude/skills/mantle-agent-config/SKILL.md
+++ b/starter-pack/.claude/skills/mantle-agent-config/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: mantle-agent-config
+description: >
+  Author or review agent.yml for a Rasa Mantle project. Use when editing agent
+  identity, persona, rules, references, voice settings, or when an agent
+  ignores its rules/guardrails despite them being "configured".
+---
+
+# agent.yml — the file with the silent failure mode
+
+## The trap this file is famous for
+
+Prompt-tuning keys nested under `agent:` **parse without error and are then
+silently discarded**. The engine's spec builder reads them only from the top
+level of the file; unknown keys inside `agent:` are ignored. A real catalog
+of ~10 projects once carried **39 rules the engine never applied** — no
+warning at train time, no error at load, found only by reading the built
+prompt. Two independent users discovered it separately.
+
+**Top-level keys (siblings of `agent:`), as of 3.20.0.dev6:**
+`name`, `description`, `rules`, `conversation`, `references`, `before_end`,
+`tool_timeout`.
+
+`tool_timeout` was added in 3.20.0.dev6 — new top-level keys appear on dev
+releases, so after an upgrade, re-check this list against the installed
+engine rather than trusting it from memory.
+
+## Correct shape
+
+```yaml
+agent:
+  id: my-agent                # stable slug
+  language: en
+  persona: |                  # multi-line, the model's standing identity
+    You are <Name>, a concise assistant for <domain>.
+    Ask one question at a time and keep answers short.
+
+# --- TOP LEVEL from here down ---
+name: <Name>
+description: <one line>
+
+rules:
+  - "Be polite, clear, and brief."
+  - "Never state data that did not come from a tool."
+```
+
+## Voice agents
+
+Voice config DOES live inside the `agent:` block:
+
+```yaml
+agent:
+  id: my-voice-agent
+  language: en
+  persona: |
+    ...
+  voice:
+    enabled: true
+    asr: deepgram                     # built-in name, or a dotted path
+    tts: deepgram                     # e.g. voicerouter.RoutedTTS
+```
+
+Custom ASR/TTS engines are referenced by dotted import path exactly like any
+custom engine class — the class must be importable from the project root.
+Voice persona tip observed to work well: instruct short spoken replies ("one
+or two short spoken sentences") — long text answers are painful read aloud.
+
+## Review checklist (run through it every time)
+
+1. Every prompt-tuning key at column 0? (`grep -n '^\s\+rules:' agent.yml`
+   must return nothing.)
+2. Persona says what the agent must NOT invent, and routes it to tools?
+3. Rules are short imperatives, not paragraphs?
+4. If voice: `voice:` inside `agent:`, engines resolvable?
+5. Run `python3 scripts/lint_mantle.py --check agent-top-level-keys` — it
+   derives the block's own indentation, so 4-space files don't slip past.

--- a/starter-pack/.claude/skills/mantle-llm-and-integrations/SKILL.md
+++ b/starter-pack/.claude/skills/mantle-llm-and-integrations/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: mantle-llm-and-integrations
+description: >
+  Configure integrations.yml — LLM model groups, providers, channels, and
+  credentials — for a Rasa Mantle project. Use when changing the LLM/provider,
+  adding channels, wiring API keys, or when validate fails with "'provider':
+  Extra inputs are not permitted" or "'model_group': Field required".
+---
+
+# integrations.yml — model groups, channels, credentials
+
+## The breaking change everyone hits
+
+Since rasa-pro **3.20.0.dev6**, the orchestrator LLM config is
+`extra="forbid"` with a **required `model_group`**. The old inline form —
+`provider:`/`model:`/`api_key:` directly under `llm:` — fails validate with:
+
+```
+'provider': Extra inputs are not permitted
+```
+
+and a missing reference fails with `'model_group': Field required`. The
+inline form is easy to reintroduce by copying any pre-dev6 example from a
+blog or older repo — assume every example you find online has this wrong.
+
+## Correct shape
+
+```yaml
+llm:
+  model_group: orchestrator
+
+model_groups:
+  - id: orchestrator
+    models:
+      - provider: openai
+        model: gpt-4.1-mini
+        api_key: ${OPENAI_API_KEY}
+        temperature: 0.0
+
+channels:
+  rest:
+    enabled: true
+  inspector:
+    enabled: true
+```
+
+- The `id` under `model_groups:` must match the `model_group:` reference.
+- `temperature: 0.0` for orchestration — routing wants determinism.
+- Alternative providers slot in at the group level (e.g.
+  `provider: gemini`, `model: gemini-2.0-flash`,
+  `api_key: ${GEMINI_API_KEY}`) — the `llm:` reference never changes.
+
+## Credentials — the three-layer resolution
+
+Keys resolve **shell env → project `.env` → repo-root `.env`**, first hit
+wins. Consequences:
+
+1. Every `${VAR}` used anywhere in yml MUST appear in `.env.example` with an
+   empty value and a comment saying where to get it. A key the example never
+   mentions is one a new user cannot discover — the failure surfaces later as
+   an unexpanded `${GEMINI_API_KEY}` that looks like a broken project.
+2. Non-default keys (anything beyond `RASA_LICENSE`/`OPENAI_API_KEY`) also go
+   in `pyproject.toml`:
+
+   ```toml
+   [tool.rasa-catalog]
+   required-secrets = ["GEMINI_API_KEY"]
+   ```
+
+3. `.env` is gitignored, always. Only `.env.example` is committed. Never put
+   a real value in any committed file — the lint scans for `sk-…` keys and
+   JWT-shaped licences.
+
+## Voice provider keys
+
+Voice vendors are optional-by-design done right: name every key in
+`.env.example` but make the runtime skip providers whose credentials are
+absent, and say so ("the router skips providers it has no credentials for").
+An agent that hard-fails on a missing optional key punishes the beginner.
+
+## Verify
+
+`python3 scripts/lint_mantle.py --check llm-model-group --check env-example
+--check secret-hygiene`, then `make validate` with real credentials.

--- a/starter-pack/.claude/skills/mantle-new-project/SKILL.md
+++ b/starter-pack/.claude/skills/mantle-new-project/SKILL.md
@@ -1,0 +1,203 @@
+---
+name: mantle-new-project
+description: >
+  Scaffold a complete, working Rasa Mantle project from scratch. Use when the
+  user wants a new Mantle/Rasa agent, a new bot project, or asks to "set up
+  Rasa". Produces every file with the correct 3.20.0.dev6 shapes so the first
+  validate passes.
+---
+
+# Scaffold a new Rasa Mantle project
+
+Ask for (or infer): the agent's **domain**, a short **persona name**, and which
+**channels** it needs (text-only vs voice). Then create every file below —
+do not skip any; each absence is a lint finding or a runtime surprise.
+
+## 1. pyproject.toml — the version facts are non-negotiable
+
+```toml
+[project]
+name = "<project-slug>"
+version = "0.1.0"
+description = "<one line>"
+readme = "README.md"
+requires-python = ">=3.11,<3.13"
+dependencies = [
+    "rasa-pro==3.20.0.dev6",
+    "python-dotenv>=1.0.0",
+]
+
+[tool.uv]
+prerelease = "allow"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["lib"]
+```
+
+WHY, so you can defend it: the Mantle engine ships **only on the
+`3.20.0.dev` pre-release line** — the newest *stable* rasa-pro contains no
+engine package at all, so "latest stable" produces a project whose imports
+fail. `prerelease = "allow"` is what lets uv resolve a dev pin. The
+`>=3.11` floor is required by 3.20; a lower floor fails `uv lock` with an
+error about "versions not supported by your dependencies" that never
+mentions Python.
+
+If the project needs credentials beyond `RASA_LICENSE` and `OPENAI_API_KEY`
+(e.g. `GEMINI_API_KEY`), also declare them:
+
+```toml
+[tool.rasa-catalog]
+required-secrets = ["GEMINI_API_KEY"]
+```
+
+## 2. lib/engine.py — the only file that imports the engine directly
+
+```python
+"""Engine imports, resolved in one place.
+
+Rasa renamed the engine package rasa.calm_v2 -> rasa.mantle in 3.20.0.dev1,
+with no alias. Every tool imports from here, never from rasa.* directly.
+"""
+from __future__ import annotations
+
+try:  # 3.20.0.dev1 and later
+    from rasa.mantle.tools.decorator import ToolContext, tool
+    from rasa.mantle.tools.result import ToolResult
+    ENGINE_PACKAGE = "rasa.mantle"
+except ImportError:  # 3.19.x and earlier
+    from rasa.calm_v2.tools.decorator import ToolContext, tool
+    from rasa.calm_v2.tools.result import ToolResult
+    ENGINE_PACKAGE = "rasa.calm_v2"
+
+__all__ = ["ENGINE_PACKAGE", "ToolContext", "ToolResult", "tool"]
+```
+
+Also create empty `lib/__init__.py` and `tools/__init__.py`.
+
+## 3. agent.yml — prompt-tuning keys are TOP-LEVEL
+
+```yaml
+agent:
+  id: <project-slug>
+  language: en
+  persona: |
+    You are <Name>, a concise assistant for <domain>.
+    Ask one question at a time and keep answers short.
+    Never invent facts — always use tools for data.
+
+# TOP-LEVEL keys, siblings of `agent:`. Nested inside they parse without
+# error and are silently discarded — the engine reads them only from the top
+# level of this file.
+name: <Name>
+description: <one line, shown to the model>
+
+rules:
+  - "Be polite, clear, and brief."
+  - "Never state data that did not come from a tool."
+  - "Activate a skill only when the request clearly matches it."
+```
+
+For a **voice** agent add, inside the `agent:` block:
+
+```yaml
+  voice:
+    enabled: true
+    asr: deepgram          # or a dotted path to a custom engine class
+    tts: deepgram
+```
+
+## 4. integrations.yml — llm is a model-group reference
+
+```yaml
+# The orchestrator LLM is a model-group reference. Provider, model and
+# credentials live on the named group, never inline under `llm:` — the
+# inline form was removed in rasa-pro 3.20.0.dev6.
+llm:
+  model_group: orchestrator
+
+model_groups:
+  - id: orchestrator
+    models:
+      - provider: openai
+        model: gpt-4.1-mini
+        api_key: ${OPENAI_API_KEY}
+        temperature: 0.0
+
+channels:
+  rest:
+    enabled: true
+  inspector:
+    enabled: true
+```
+
+## 5. memory.yml — project memory is tool-written
+
+```yaml
+# Project memory — facts that outlive a single skill. Readable and writable
+# by EVERY skill. Keep it to facts about the end user and the session.
+# NEVER put `llm_settable: true` here — the engine rejects it at the project
+# level. LLM-settable fields belong in skills/<id>/memory.yml.
+authenticated:
+  type: bool
+  description: Whether the caller has proven their identity this session.
+  initial_value: false
+```
+
+## 6. Skills — at least one real skill plus a greeting
+
+Create `skills/<skill_id>/skill.md` using the **mantle-skill-authoring**
+skill's grammar (frontmatter → prose → top-level `if:` branches). Put tools
+only that skill uses in `skills/<skill_id>/tools.py`; shared tools in
+`tools/` and reference them with `import_tools:` in the frontmatter.
+
+## 7. Credentials and hygiene
+
+- `.env.example` (committed): every key the project reads, values empty, one
+  comment per key saying where to get it. Start with:
+
+  ```bash
+  # Rasa Pro licence (free Developer Edition, a long JWT, one line)
+  RASA_LICENSE=
+  # LLM for routing and conversation
+  OPENAI_API_KEY=
+  ```
+
+- `.gitignore` must contain: `.env`, `.venv/`, `models/`, `__pycache__/`,
+  `.rasa/`.
+
+## 8. Makefile — the beginner's interface
+
+```makefile
+.DEFAULT_GOAL := help
+.PHONY: help env install validate train chat lint clean
+
+help: ## Show targets
+	@grep -E '^[a-z-]+:.*##' $(MAKEFILE_LIST) | awk -F':.*## ' '{printf "  make %-10s %s\n", $$1, $$2}'
+env: ## Create .env from .env.example
+	@test -f .env || cp .env.example .env
+install: ## Install dependencies
+	uv sync --prerelease=allow
+lint: ## Offline consistency checks
+	python3 scripts/lint_mantle.py
+validate: lint ## Validate the project without training
+	uv run rasa validate
+train: ## Validate and train
+	uv run rasa train
+chat: ## Talk to the agent in the Inspector
+	uv run rasa inspect
+clean: ## Remove models and caches
+	rm -rf models .rasa
+```
+
+## 9. Finish
+
+1. Copy `scripts/lint_mantle.py` and `hooks/` from the starter pack if not
+   present; run `./hooks/install-hooks.sh`.
+2. Run `python3 scripts/lint_mantle.py` — must be clean before the first commit.
+3. Tell the user exactly which of the two gates you ran: the offline lint
+   (consistency) vs `make validate`/`train` (actually exercises the engine —
+   needs `uv sync` and a `RASA_LICENSE`). A green lint alone is not "it works".

--- a/starter-pack/.claude/skills/mantle-skill-authoring/SKILL.md
+++ b/starter-pack/.claude/skills/mantle-skill-authoring/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: mantle-skill-authoring
+description: >
+  Write or fix a Rasa Mantle skill.md. Use when creating a new skill, when a
+  skill's conditional branches never fire, when memory values appear as
+  literal text in replies, or when designing skill activation/routing.
+---
+
+# skill.md — three languages in one file
+
+A skill.md is three different languages stacked, and most authoring bugs come
+from treating them as one:
+
+1. **YAML frontmatter** — structured config, never prose.
+2. **Markdown body** — instruction prose the LLM reads, EXCEPT top-level `if:`.
+3. **`:::block … :::` regions** — YAML again; only `instructions:` scalar
+   bodies inside them are prose.
+
+## 1. Frontmatter
+
+```yaml
+---
+name: Check Balance
+description: >
+  Tell the caller the balance of one account. Activate for balance, how much
+  is in my account, or available funds.
+import_tools:            # shared tools from the project-level tools/ dir
+  - get_customer_info
+tool_constraints:        # gate a tool on a memory field being set
+  - get_recent_transactions:
+      requires: session.view_transactions.selected_account_id
+routing:
+  engine_managed: true   # for openers like session-start skills
+---
+```
+
+The `description` doubles as the activation hint — write the trigger phrases
+into it ("Activate for X, Y, or Z"), it is how the router matches requests
+to skills.
+
+## 2. Body prose — what substitutes and what doesn't
+
+- `@memory.<namespace>.<entry>` — **exactly three dot-separated parts** — is
+  substituted with the live value. `@memory.project.customer_name` works;
+  `@memory.customer_name` is dead text delivered to the LLM verbatim.
+- Raw `session.x.y` in prose is **never substituted**. It belongs in `if:`
+  conditions and `tool_constraints`, nowhere else. If you need the value in
+  prose, use the `@memory` form.
+
+## 3. Branching — `if:` at column 0 only
+
+```markdown
+if: not session.view_transactions.selected_account_id and session.project.default_account_id
+The customer has a usual account on file: @memory.project.default_account_label.
+Offer that one first by name. If they say yes, set `selected_account_id` via
+`set_fields` to @memory.project.default_account_id.
+
+if: session.view_transactions.selected_account_id
+Call `get_recent_transactions` for the selected account and present the rows
+briefly (date, merchant, amount).
+```
+
+- Conditions reference `session.<skill_id>.<field>` (this skill's memory) and
+  `session.project.<field>` (project memory), combined with `not` / `and`.
+- **An indented `if:` is not parsed as a condition** — it stays instruction
+  prose and your branch silently never branches. If you want a conditional
+  inside a paragraph, express it in natural language instead.
+- Write branch sets that cover the state space: typically
+  `not set and have-default` / `not set and no-default` / `set`.
+
+## 4. Deterministic sequences — ordered blocks
+
+For fixed step sequences (e.g. a session opener), skip prose entirely:
+
+```markdown
+:::ordered_block id=main
+steps:
+  - id: identify
+    execute_tool: get_customer_profile
+  - id: greet
+    action: utter_greet
+:::
+```
+
+## 5. Skill-scoped memory — `skills/<id>/memory.yml`
+
+This is where `llm_settable` belongs (NOT the root memory.yml):
+
+```yaml
+schema:
+  public:
+    account_number:
+      type: text
+      description: Account the caller asked about.
+      llm_settable: true
+```
+
+The LLM writes these via `set_fields`; instruct it explicitly in prose:
+"set `selected_account_id` via `set_fields` to the matching id from the tool
+result" — and name what it must NOT set or invent.
+
+## 6. Style rules that ship in every good skill here
+
+- One skill = one user goal. Local tools in `skills/<id>/tools.py`; anything
+  two skills need moves to `tools/` + `import_tools`.
+- State the negative space: "Never state a balance in that case", "Do not
+  invent accounts". Mantle personas follow prohibitions well when explicit.
+- Hand off across skills through project memory, not prose assumptions:
+  "`fetch_balance` reads the signed-in customer from project memory, so it is
+  the authority on whether the caller is verified."
+
+## 7. Verify
+
+`python3 scripts/lint_mantle.py --check nested-if --check skill-prose` — then
+`make validate` for the engine's own view.

--- a/starter-pack/.claude/skills/mantle-tools-and-memory/SKILL.md
+++ b/starter-pack/.claude/skills/mantle-tools-and-memory/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: mantle-tools-and-memory
+description: >
+  Write Rasa Mantle tools (Python) and design memory scoping. Use when adding
+  a tool, when a tool isn't discovered, when deciding local vs shared tools,
+  or when choosing project memory vs skill memory.
+---
+
+# Tools and memory — the scoping model
+
+## The two scopes, one sentence each
+
+- **Project memory (`memory.yml`, repo root):** facts that outlive a single
+  skill — identity, preferences, session state. Every skill reads and writes
+  it. **Tool-written only**: `llm_settable: true` here is rejected by the
+  engine at validate time.
+- **Skill memory (`skills/<id>/memory.yml`):** one skill's working state,
+  under `schema: public:`. This is where `llm_settable: true` is allowed.
+
+Rule of thumb: if a later skill could skip work because of it (customer id,
+authenticated flag, chosen language) → project memory, set by a tool. If it
+only matters until this skill finishes (which account they asked about) →
+skill memory, settable by the LLM.
+
+## Writing a tool
+
+Always import from the project's shim, never from `rasa.*` directly:
+
+```python
+"""LOCAL tool for check_balance — reading a balance is this skill's job alone."""
+from __future__ import annotations
+
+from lib.engine import ToolContext, ToolResult, tool
+
+
+@tool(description="Return the balance of one of the signed-in customer's accounts.")
+async def fetch_balance(account_number: str, context: ToolContext = None) -> ToolResult:
+    """Look up a single account balance.
+
+    Args:
+        account_number: The account number to read.
+    """
+    customer_id = context.memory.get("project.customer_id") if context else None
+    if not customer_id:
+        return ToolResult(llm_response={"ok": False, "error": "not_authenticated"})
+
+    account = lookup(customer_id, account_number)
+    if account is None:
+        return ToolResult(llm_response={"ok": False, "error": "account_not_found"})
+
+    if context is not None:
+        context.memory.set("account_number", account_number)  # skill scope
+
+    return ToolResult(llm_response={
+        "ok": True, "account_number": account_number,
+        "balance": account.balance, "currency": "GBP",
+    })
+```
+
+The load-bearing facts:
+
+- **Discovery is by the `_tool_description` attribute the `@tool` decorator
+  sets** — where you import the decorator from makes no difference, which is
+  why the `lib/engine.py` shim is safe.
+- Tools are `async def`, take typed args plus `context: ToolContext = None`,
+  and return `ToolResult(llm_response={...})`.
+- `context.memory.get("project.<field>")` reads project memory;
+  `context.memory.set("<field>", value)` writes this skill's scope.
+- Return **structured dicts with an `ok`/`error` shape**, never prose. Error
+  values like `"not_authenticated"` become branch points in skill prose
+  ("If it returns `not_authenticated`, tell the caller you need to verify
+  them first"). Include recovery data on errors (e.g. `known_accounts`).
+
+## Local vs shared
+
+- `skills/<id>/tools.py` — tools only that skill uses. No registration needed.
+- `tools/` (project root) — tools used by 2+ skills; each consuming skill
+  lists them under `import_tools:` in its frontmatter. Document the choice in
+  the docstring ("shared with other skills, so it is imported rather than
+  living in this skill's folder").
+
+## Authority pattern (the one worth copying everywhere)
+
+Make ONE tool the authority for each invariant, and let skills defer to it:
+the balance tool checks authentication itself by reading
+`project.customer_id`, so no skill can leak a balance by forgetting a check —
+the prose then says the tool "is the authority on whether the caller is
+verified." Guardrails in tools are enforced; guardrails only in prose are
+requests.
+
+## Verify
+
+- `python3 scripts/lint_mantle.py --check project-memory-writes`
+- `make validate` (engine-level: rejects root `llm_settable`, missing tools,
+  bad constraints)

--- a/starter-pack/.claude/skills/mantle-upgrade-and-debug/SKILL.md
+++ b/starter-pack/.claude/skills/mantle-upgrade-and-debug/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: mantle-upgrade-and-debug
+description: >
+  Diagnose Rasa Mantle failures and perform version upgrades. Use when an
+  install/lock/validate/train fails, when imports break after a version bump,
+  when the agent ignores configuration, or when deciding which rasa-pro
+  version to pin.
+---
+
+# Upgrades and the failure→cause map
+
+Most Mantle failures report a symptom far from their cause. Look the message
+up here BEFORE debugging from first principles.
+
+## The failure→cause map
+
+| You see | Actual cause | Fix |
+| --- | --- | --- |
+| `ModuleNotFoundError: rasa.mantle` (or nothing importable) after pinning "latest stable" | The engine ships **only on `3.20.0.dev*`**; stable releases contain no engine package | Pin `rasa-pro==3.20.0.dev6`, `[tool.uv] prerelease = "allow"` |
+| `ModuleNotFoundError: rasa.calm_v2` after an upgrade | Package renamed `rasa.calm_v2` → `rasa.mantle` at 3.20.0.dev1, no alias | Route all engine imports through a `lib/engine.py` try/except shim |
+| `uv lock`: "versions that are not supported by your dependencies (e.g., rasa-pro==3.20.0.dev6 only supports >=3.11, <3.15)" | `requires-python` floor below 3.11 — the error never says "Python" | Set `requires-python = ">=3.11,<3.13"` |
+| validate: `'provider': Extra inputs are not permitted` | Inline LLM config under `llm:` — removed in dev6 (`extra="forbid"`) | `llm: {model_group: <id>}` + a `model_groups:` entry |
+| validate: `'model_group': Field required` | `llm:` block exists but names no group | Same as above |
+| validate rejects root `memory.yml` | `llm_settable: true` on project-level memory | Move the field to `skills/<id>/memory.yml`, or have a tool write it |
+| Agent ignores its rules/name/references; no error anywhere | Prompt-tuning keys nested under `agent:` — parsed then silently discarded | Move them to the top level of agent.yml |
+| A skill branch never fires; no error | `if:` is indented — it's prose, not a condition | Move `if:` to column 0 of the skill body |
+| Literal `@memory.foo` or `session.x.y` text in replies | Token not substitutable: `@memory` needs exactly 3 parts; `session.*` never substitutes in prose | Use `@memory.<ns>.<entry>`, keep `session.*` in `if:`/constraints |
+| Unexpanded `${SOME_KEY}` at train time | Key missing from environment and `.env` | Add to `.env` (and to `.env.example` + `required-secrets` so the next person finds it) |
+| `rasa init --engine <retired-name>` rejected | The pre-Mantle brand was retired; CLI accepts `{calm,mantle}` | Use `mantle`; purge the old name from docs — a stale brand in a runnable command is a broken command. (The name is not written out here so this file passes the very lint that catches it.) |
+
+## Upgrading the pin (e.g. dev6 → dev7)
+
+1. **Verify the target ships the engine before touching anything.** The
+   authority is the published wheel's module list, not release notes: check
+   that the wheel contains `rasa/mantle/`. If you can't check, upgrade one
+   throwaway venv first and `python -c "import rasa.mantle"`.
+2. Bump `rasa-pro==<target>` in pyproject.toml, run
+   `uv lock` / `uv sync --prerelease=allow`.
+3. **Sweep the prose too**: README "Verified with:", version mentions in
+   docs. Do it with care — a careless sweep rewrites upgrade-path lines into
+   `X → X` nonsense (this exact defect shipped in a real migration).
+4. Re-derive the top-level agent.yml key list from the installed engine —
+   dev releases add keys (`tool_timeout` arrived in dev6 unannounced). If
+   the engine's agent-spec payload reads a key your tooling doesn't know,
+   update the tooling's list.
+5. Run the full ladder and say which rungs you ran:
+   `lint_mantle.py` (offline consistency) → `rasa validate` → `rasa train`.
+   **A green offline lint does NOT test the engine contract** — only an
+   installed engine does. Never report "upgrade verified" off the lint alone.
+
+## Debugging discipline (earned the hard way)
+
+Before asserting any diagnosis, name the one cheap command that would prove
+it wrong and run it — `git log --format=%cI`, a `grep` of the committed file,
+one import in a venv. Most wrong turns in real Mantle debugging sessions came
+from acting on the first plausible reading of a symptom; every one would have
+been caught by a single command run before concluding.

--- a/starter-pack/CLAUDE.md
+++ b/starter-pack/CLAUDE.md
@@ -1,0 +1,68 @@
+# <PROJECT NAME> — a Rasa Mantle agent
+
+This repository is a Rasa Mantle (Skills engine) project. The rules below are
+not style preferences — each one encodes a failure mode that is silent or
+misleadingly reported by the engine, verified against rasa-pro `3.20.0.dev6`.
+
+## Version doctrine (read before touching pyproject.toml)
+
+- The Mantle engine ships **only on the `3.20.0.dev` pre-release line**. The
+  newest stable `rasa-pro` has **no engine package**. Never "upgrade to latest
+  stable"; pin `rasa-pro==3.20.0.dev6` (or the current dev release) and keep
+  `[tool.uv] prerelease = "allow"`.
+- `requires-python = ">=3.11,<3.13"`. A lower floor fails `uv lock` with a
+  resolver error that never mentions Python.
+- Engine imports live in `lib/engine.py` and nowhere else. The package was
+  renamed `rasa.calm_v2` → `rasa.mantle` in 3.20.0.dev1 with no alias; the
+  shim is the one place that knows this.
+
+## Layout
+
+```
+agent.yml            # identity + persona; prompt-tuning keys at TOP LEVEL
+integrations.yml     # llm -> model_group reference; model_groups; channels
+memory.yml           # PROJECT memory: tool-written facts, never llm_settable
+skills/<id>/skill.md # one skill per folder
+skills/<id>/tools.py # tools only this skill uses
+skills/<id>/memory.yml  # skill-scoped memory; llm_settable lives HERE
+tools/               # shared tools, referenced via import_tools
+lib/engine.py        # the only file that imports rasa.mantle directly
+.env.example         # every credential the project reads, committed
+.env                 # real credentials, gitignored, never committed
+```
+
+## The five silent traps (the lint enforces all of them)
+
+1. **`name:`, `description:`, `rules:`, `references:`, `conversation:`,
+   `before_end:`, `tool_timeout:` are SIBLINGS of `agent:` in agent.yml, never
+   children.** Nested inside they parse without error and are discarded.
+2. **`llm:` in integrations.yml is a model-group reference**
+   (`llm: {model_group: <id>}`). Inline `provider`/`model`/`api_key` there is
+   rejected since 3.20.0.dev6. Providers/credentials live on the
+   `model_groups:` entry, with `api_key: ${SOME_ENV_VAR}`.
+3. **Root `memory.yml` may not contain `llm_settable: true`.** Project memory
+   is written by tools. LLM-settable fields go in `skills/<id>/memory.yml`
+   under `schema: public:`.
+4. **In skill.md, `if:` only works at column 0** of the body. Indented `if:` is
+   prose. Conditions use `session.<skill>.<field>` / `session.project.<field>`.
+5. **In skill prose, only `@memory.<namespace>.<entry>` (exactly three parts)
+   is substituted.** Raw `session.x.y` in prose reaches the LLM as dead text.
+
+## Workflow
+
+- Scaffold or extend with the `.claude/skills/mantle-*` skills — they carry the
+  full templates and grammar.
+- Gate before every commit: `python3 scripts/lint_mantle.py` (the pre-commit
+  hook runs it for you — install once with `./hooks/install-hooks.sh`).
+- The lint is offline and answers "internally consistent?". Only
+  `uv sync` + `rasa validate`/train answers "does it actually run?" — a green
+  lint is necessary, not sufficient. Say which one you ran.
+- Never commit `.env`. Credentials resolve shell → project `.env`; put every
+  needed key name in `.env.example` with an empty value.
+
+## When something fails, check the map first
+
+`.claude/skills/mantle-upgrade-and-debug/SKILL.md` has a failure→cause table
+(`'provider': Extra inputs are not permitted`, resolver errors, import errors
+after upgrades). Most Mantle failures report a symptom far from their cause;
+look the message up before debugging from first principles.

--- a/starter-pack/README.md
+++ b/starter-pack/README.md
@@ -1,0 +1,83 @@
+# Rasa Mantle starter pack
+
+Everything here is distilled from the byte-verified projects in this catalog —
+each rule below encodes a failure a real project in this repository actually
+hit, not a guess about what might go wrong.
+
+**Who this is for:** someone who has never built a Rasa Mantle agent and wants
+to ship a good one fast, with tooling that catches the known traps before they
+cost an afternoon.
+
+## What's in the box
+
+```
+starter-pack/
+├── CLAUDE.md                          # drop into your new repo root
+├── .claude/
+│   ├── skills/                        # Claude Code skills (auto-discovered)
+│   │   ├── mantle-new-project/        # scaffold a working project
+│   │   ├── mantle-agent-config/       # agent.yml without the silent traps
+│   │   ├── mantle-skill-authoring/    # skill.md grammar that actually parses
+│   │   ├── mantle-tools-and-memory/   # tool scope, memory scope, ToolResult
+│   │   ├── mantle-llm-and-integrations/ # model groups, channels, credentials
+│   │   └── mantle-upgrade-and-debug/  # version pins, rename, failure→cause map
+│   └── agents/
+│       ├── mantle-builder.md          # role: implements against the checklist
+│       └── mantle-reviewer.md         # role: reviews bytes, runs the lint
+├── scripts/
+│   └── lint_mantle.py                 # standalone, zero-dependency project lint
+└── hooks/
+    ├── pre-commit                     # runs the lint on every commit
+    └── install-hooks.sh               # one command to wire it up
+```
+
+## Ten-minute start
+
+```bash
+# 1. Copy the pack into your new project repo
+cp -R starter-pack/CLAUDE.md starter-pack/.claude starter-pack/scripts starter-pack/hooks  my-agent/
+cd my-agent && git init
+
+# 2. Install the git hook (lint runs on every commit from now on)
+./hooks/install-hooks.sh
+
+# 3. Open Claude Code and say:
+#      "use the mantle-new-project skill to scaffold a <your domain> agent"
+#    The skill scaffolds every file with the correct 2026 shapes.
+
+# 4. Gate it yourself any time:
+python3 scripts/lint_mantle.py
+```
+
+## The one fact that breaks everything if you miss it
+
+The Mantle engine (`rasa.mantle`) ships **only on the pre-release line**
+`3.20.0.dev*`. The newest *stable* `rasa-pro` on PyPI contains **no engine
+package at all** — pinning "latest stable" produces a project that cannot
+import a single tool. Pin a `3.20.0.dev` release and set
+`[tool.uv] prerelease = "allow"`. The lint checks this.
+
+## What the lint catches ahead of time
+
+Every check maps to a real, named failure (see `scripts/lint_mantle.py`
+docstrings for the full story):
+
+| Check | The failure it prevents |
+| --- | --- |
+| `agent-top-level-keys` | `rules:`/`name:`/`references:` nested under `agent:` parse fine and are **silently discarded** — an agent running without its guardrails, no warning anywhere. |
+| `llm-model-group` | Inline `provider:`/`model:` under `llm:` — rejected since 3.20.0.dev6 with `'provider': Extra inputs are not permitted`, only at validate time. |
+| `project-memory-writes` | `llm_settable: true` in root `memory.yml` — the engine rejects it outright; it belongs in skill-scoped memory. |
+| `nested-if` | An indented `if:` in a skill body is instruction prose, not a condition. Your branch never branches. |
+| `skill-prose` | Raw `session.x.y` in prose is **not substituted**; only `@memory.<ns>.<entry>` (exactly three parts) is. |
+| `engine-version-pin` | Stable pin / missing `prerelease = "allow"` / Python floor below 3.11 — each fails with an error message that never names the actual cause. |
+| `secret-hygiene` | A committed `.env`, an `sk-…` key or a JWT licence in tracked text. |
+| `env-example` | A required credential your `.env.example` never mentions — undiscoverable until train breaks. |
+| `retired-brand` | The retired pre-Mantle product name in a runnable command — the CLI already rejects it. (Not written out here; the lint that catches it scans this file too.) |
+
+## Provenance
+
+Assembled 2026-09-02 from `RasaHQ/rasa-community-resources` at rasa-pro
+`3.20.0.dev6`: the catalog's `scripts/lint_repo.py` (every check there "encodes
+a failure this repository has actually hit"), `docs/MIGRATING.md`, and the
+shipped tutorials/examples/patterns. When the engine reaches a stable release,
+re-check the version guidance here first — it is the piece most likely to age.

--- a/starter-pack/README.md
+++ b/starter-pack/README.md
@@ -1,83 +1,251 @@
-# Rasa Mantle starter pack
+# 🚀 Rasa Mantle Starter Pack
 
-Everything here is distilled from the byte-verified projects in this catalog —
-each rule below encodes a failure a real project in this repository actually
-hit, not a guess about what might go wrong.
+**Build your first Rasa Mantle agent — with training wheels that actually work.**
 
-**Who this is for:** someone who has never built a Rasa Mantle agent and wants
-to ship a good one fast, with tooling that catches the known traps before they
-cost an afternoon.
+Hi! If you're new to Rasa Mantle (or new to building AI agents at all),
+you're in the right place. This pack gives you three things:
 
-## What's in the box
+1. **A smart assistant setup** — ready-made instructions that teach Claude
+   Code how to build Mantle projects *correctly*, so you can just describe
+   what you want.
+2. **A safety net** — a small checker program that catches the most common
+   Mantle mistakes *before* they waste your afternoon.
+3. **An automatic guard** — a one-time setup that runs the checker every
+   time you save your work, so mistakes can't sneak in.
 
-```
-starter-pack/
-├── CLAUDE.md                          # drop into your new repo root
-├── .claude/
-│   ├── skills/                        # Claude Code skills (auto-discovered)
-│   │   ├── mantle-new-project/        # scaffold a working project
-│   │   ├── mantle-agent-config/       # agent.yml without the silent traps
-│   │   ├── mantle-skill-authoring/    # skill.md grammar that actually parses
-│   │   ├── mantle-tools-and-memory/   # tool scope, memory scope, ToolResult
-│   │   ├── mantle-llm-and-integrations/ # model groups, channels, credentials
-│   │   └── mantle-upgrade-and-debug/  # version pins, rename, failure→cause map
-│   └── agents/
-│       ├── mantle-builder.md          # role: implements against the checklist
-│       └── mantle-reviewer.md         # role: reviews bytes, runs the lint
-├── scripts/
-│   └── lint_mantle.py                 # standalone, zero-dependency project lint
-└── hooks/
-    ├── pre-commit                     # runs the lint on every commit
-    └── install-hooks.sh               # one command to wire it up
-```
+You don't need to know what a "linter" or a "git hook" is. We'll explain
+everything as we go. 💪
 
-## Ten-minute start
+---
+
+## Why does this exist? (30 seconds of honesty)
+
+Rasa Mantle is powerful, but it has a handful of traps that are **silent** —
+you make the mistake, nothing complains, and your agent just quietly
+misbehaves. For example: put your agent's rules in *slightly* the wrong spot
+in a config file, and Mantle reads them, throws them away, and never tells
+you. Real projects shipped with 39 rules the engine never applied, and
+nobody noticed for weeks.
+
+Every check and every instruction in this pack comes from a **real mistake a
+real project actually made**. We stepped on the rakes so you don't have to.
+
+---
+
+## What you need before starting
+
+| Tool | What it is | How to get it |
+| --- | --- | --- |
+| **Python 3.11 or newer** | The language Mantle runs on | [python.org/downloads](https://www.python.org/downloads/) — check with `python3 --version` |
+| **git** | Saves snapshots of your work | Usually pre-installed — check with `git --version` |
+| **uv** | Installs Python packages, fast | [docs.astral.sh/uv](https://docs.astral.sh/uv/) — one command to install |
+| **Claude Code** | The AI assistant this pack teaches | [claude.com/claude-code](https://claude.com/claude-code) |
+| **A Rasa license** | Free for developers | [Request a free Developer Edition key](https://rasa.com/rasa-pro-developer-edition-license-key-request/) |
+| **An OpenAI API key** | Powers your agent's brain | [platform.openai.com](https://platform.openai.com/) |
+
+Don't have everything yet? That's fine — you can do steps 1–3 below with
+just Python and git, and add the keys when you're ready to run the agent.
+
+---
+
+## Setting up (about 10 minutes)
+
+### Step 1 — Make a folder for your project
+
+Open a terminal and run these lines one at a time:
 
 ```bash
-# 1. Copy the pack into your new project repo
-cp -R starter-pack/CLAUDE.md starter-pack/.claude starter-pack/scripts starter-pack/hooks  my-agent/
-cd my-agent && git init
+mkdir my-agent
+cd my-agent
+git init
+```
 
-# 2. Install the git hook (lint runs on every commit from now on)
-./hooks/install-hooks.sh
+`git init` tells git "please track my work in this folder." You only ever
+run it once per project.
 
-# 3. Open Claude Code and say:
-#      "use the mantle-new-project skill to scaffold a <your domain> agent"
-#    The skill scaffolds every file with the correct 2026 shapes.
+### Step 2 — Copy the starter pack in
 
-# 4. Gate it yourself any time:
+Copy these four things from the starter pack into your new folder:
+
+```bash
+cp -R /path/to/starter-pack/CLAUDE.md .
+cp -R /path/to/starter-pack/.claude .
+cp -R /path/to/starter-pack/scripts .
+cp -R /path/to/starter-pack/hooks .
+```
+
+(Replace `/path/to/starter-pack` with wherever you downloaded this pack.)
+
+What did you just copy?
+
+- `CLAUDE.md` — the rulebook Claude Code reads automatically when it works
+  in your folder.
+- `.claude/` — six "skills" (step-by-step playbooks for building Mantle
+  pieces) and two "roles" (a builder and a reviewer). Claude Code finds
+  these on its own; you don't need to do anything with them.
+- `scripts/` — the checker program (more on it in a second).
+- `hooks/` — the automatic guard (more on it in Step 4).
+
+> 💡 **Heads-up:** `.claude` starts with a dot, which means your file
+> browser probably hides it. It's there — `ls -a` in the terminal shows it.
+
+### Step 3 — Try the checker
+
+The checker (`lint_mantle.py`) is a small program that reads your project
+files and looks for the known Mantle traps. Programmers call this kind of
+tool a **linter** — it "picks the lint off" your code. Run it:
+
+```bash
 python3 scripts/lint_mantle.py
 ```
 
-## The one fact that breaks everything if you miss it
+Right now your project is nearly empty, so you'll see a few findings like
+"missing pyproject.toml" — **that's normal and good!** It means the checker
+works. Each line tells you exactly what's missing and how to fix it. A fully
+set-up project prints:
 
-The Mantle engine (`rasa.mantle`) ships **only on the pre-release line**
-`3.20.0.dev*`. The newest *stable* `rasa-pro` on PyPI contains **no engine
-package at all** — pinning "latest stable" produces a project that cannot
-import a single tool. Pin a `3.20.0.dev` release and set
-`[tool.uv] prerelease = "allow"`. The lint checks this.
+```
+ok — 0 finding(s) across 9 check(s)
+```
 
-## What the lint catches ahead of time
+That's the goal. Green means go.
 
-Every check maps to a real, named failure (see `scripts/lint_mantle.py`
-docstrings for the full story):
+### Step 4 — Turn on the automatic guard
 
-| Check | The failure it prevents |
+Now the neat part. Git has a feature called **hooks**: little programs that
+run automatically at key moments. We'll install one that runs the checker
+every time you *commit* (= save a snapshot of your work):
+
+```bash
+./hooks/install-hooks.sh
+```
+
+You'll see:
+
+```
+Installed: .git/hooks/pre-commit
+Every commit now runs: python3 scripts/lint_mantle.py
+```
+
+From now on, if you try to save work that contains one of the known traps,
+git will stop and show you exactly what's wrong:
+
+```
+COMMIT BLOCKED by lint_mantle.py (exit 1).
+Each finding above names its fix.
+```
+
+This isn't punishment — it's the pack catching a silent bug **now**, while
+it's a 30-second fix, instead of **later**, when it's a mystery. Fix what
+the message says, then commit again. That's the whole workflow.
+
+> 💡 You only run `install-hooks.sh` once per project. The guard stays on.
+
+### Step 5 — Let Claude Code build your agent
+
+Open Claude Code inside your project folder and say something like:
+
+> "Use the **mantle-new-project** skill to scaffold a customer-support agent
+> for a small bakery. Call it Poppy."
+
+Claude Code will read the skill (a detailed playbook that knows all the
+correct file shapes) and create every file your agent needs. When it's done,
+run the checker again — it should say `ok`.
+
+Then bring your agent to life:
+
+```bash
+make env        # creates your personal .env file for API keys
+# open .env in any editor and paste in your RASA_LICENSE and OPENAI_API_KEY
+make install    # downloads Rasa Mantle (takes a few minutes the first time)
+make train      # teaches the engine your agent
+make chat       # talk to your agent! 🎉
+```
+
+---
+
+## Everyday cheat sheet
+
+| You want to… | Run this |
 | --- | --- |
-| `agent-top-level-keys` | `rules:`/`name:`/`references:` nested under `agent:` parse fine and are **silently discarded** — an agent running without its guardrails, no warning anywhere. |
-| `llm-model-group` | Inline `provider:`/`model:` under `llm:` — rejected since 3.20.0.dev6 with `'provider': Extra inputs are not permitted`, only at validate time. |
-| `project-memory-writes` | `llm_settable: true` in root `memory.yml` — the engine rejects it outright; it belongs in skill-scoped memory. |
-| `nested-if` | An indented `if:` in a skill body is instruction prose, not a condition. Your branch never branches. |
-| `skill-prose` | Raw `session.x.y` in prose is **not substituted**; only `@memory.<ns>.<entry>` (exactly three parts) is. |
-| `engine-version-pin` | Stable pin / missing `prerelease = "allow"` / Python floor below 3.11 — each fails with an error message that never names the actual cause. |
-| `secret-hygiene` | A committed `.env`, an `sk-…` key or a JWT licence in tracked text. |
-| `env-example` | A required credential your `.env.example` never mentions — undiscoverable until train breaks. |
-| `retired-brand` | The retired pre-Mantle product name in a runnable command — the CLI already rejects it. (Not written out here; the lint that catches it scans this file too.) |
+| Check your project for traps | `python3 scripts/lint_mantle.py` |
+| Check just one thing | `python3 scripts/lint_mantle.py --check nested-if` |
+| See all check names | `python3 scripts/lint_mantle.py --list` |
+| Add a new skill to your agent | Ask Claude Code to "use the mantle-skill-authoring skill" |
+| Change the AI model / provider | Ask for the "mantle-llm-and-integrations skill" |
+| Something's broken and weird | Ask for the "mantle-upgrade-and-debug skill" — it has a table mapping error messages to real causes |
+| Get your work reviewed | Ask Claude Code to "review this as mantle-reviewer" |
 
-## Provenance
+---
+
+## When the checker complains — what the messages mean
+
+Every message names its own fix, but here's the plain-English version of
+what each check protects you from:
+
+- **agent-top-level-keys** — Your agent's rules are in a spot where Mantle
+  *silently ignores them*. Move them where the message says. (This is the
+  39-ignored-rules bug. It makes no error sound at all. The checker is the
+  only alarm.)
+- **llm-model-group** — Your AI-model settings use an old format that new
+  Mantle versions reject. Most tutorials on the internet still show the old
+  format, so this one bites everyone.
+- **project-memory-writes** — A memory field is marked "the AI may write
+  this" in a file where that's not allowed. The fix is a one-line move.
+- **nested-if** — An `if:` line is indented, so Mantle treats it as plain
+  text instead of logic. Your branch never runs. Un-indent it.
+- **skill-prose** — You referenced a memory value in a way that won't be
+  filled in — the user would literally see `session.project.name` as text.
+- **engine-version-pin** — Your project points at a Rasa version that
+  doesn't contain the Mantle engine at all. ⚠️ This is the big one:
+  **the newest "stable" Rasa has no Mantle inside** — you need a
+  `3.20.0.dev` version, even though "dev" sounds scarier than "stable".
+- **secret-hygiene** — An API key or password is about to be saved into git
+  history (which is very hard to un-do, and public if you ever share the
+  repo). Move it into `.env`, which git is told to ignore.
+- **env-example** — Your project uses a key that `.env.example` doesn't
+  mention, so the next person (or future-you) can't discover they need it.
+- **retired-brand** — You used the old product name for the engine.
+  Commands with the old name don't just look dated — they *fail*.
+
+---
+
+## FAQ
+
+**Do I have to use the checker? It blocked my commit!**
+You can bypass it once with `git commit --no-verify`, but the checker only
+speaks up about mistakes that are *silent* at runtime — so bypassing it
+usually means shipping a bug you won't see until much later. If you're sure
+it's wrong, bypass and say why in your commit message.
+
+**The checker says my Rasa version is wrong, but I picked the newest one!**
+That's the trap. The Mantle engine currently ships **only in pre-release
+("dev") versions**. The newest stable release literally does not contain the
+engine. Pin `rasa-pro==3.20.0.dev6` — the skills do this for you.
+
+**`make install` fails with a confusing message about versions.**
+Nine times out of ten this is the Python floor: Mantle needs Python 3.11+,
+and the error message doesn't mention Python at all. The
+mantle-upgrade-and-debug skill's table covers this and friends.
+
+**Can I use this without Claude Code?**
+Yes! The checker and the git hook work on their own. The `.claude/skills/`
+files are also just well-organized Markdown — they're a solid Mantle
+handbook for humans too.
+
+**Is my API key safe?**
+Keys live in `.env`, which is never saved to git, and the checker actively
+scans for keys accidentally pasted anywhere else. Just never edit
+`.env.example` to contain a *real* value — that file IS saved to git.
+
+---
+
+## Where this all comes from
 
 Assembled 2026-09-02 from `RasaHQ/rasa-community-resources` at rasa-pro
-`3.20.0.dev6`: the catalog's `scripts/lint_repo.py` (every check there "encodes
-a failure this repository has actually hit"), `docs/MIGRATING.md`, and the
-shipped tutorials/examples/patterns. When the engine reaches a stable release,
-re-check the version guidance here first — it is the piece most likely to age.
+`3.20.0.dev6`. Every rule was distilled from that catalog's shipped
+projects and its own checker — each one encodes a failure a real project
+actually hit. When Mantle reaches a stable release, the version advice
+above is the part to re-check first.
+
+Happy building! 🛠️

--- a/starter-pack/hooks/install-hooks.sh
+++ b/starter-pack/hooks/install-hooks.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Wire the starter-pack pre-commit gate into this repository's git hooks.
+# Idempotent; refuses to clobber an unrelated existing hook.
+set -euo pipefail
+
+here="$(cd "$(dirname "$0")" && pwd)"
+git_dir="$(git rev-parse --git-dir 2>/dev/null)" || {
+  echo "Not a git repository — run 'git init' first." >&2
+  exit 1
+}
+
+hook="$git_dir/hooks/pre-commit"
+src="$here/pre-commit"
+
+if [ -e "$hook" ] && ! grep -q "lint_mantle.py" "$hook"; then
+  echo "Refusing to overwrite an existing unrelated pre-commit hook at:" >&2
+  echo "  $hook" >&2
+  echo "Merge it manually with $src" >&2
+  exit 1
+fi
+
+cp "$src" "$hook"
+chmod +x "$hook"
+echo "Installed: $hook"
+echo "Every commit now runs: python3 scripts/lint_mantle.py"

--- a/starter-pack/hooks/pre-commit
+++ b/starter-pack/hooks/pre-commit
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Pre-commit gate for a Rasa Mantle project: offline, stdlib-only, fast.
+# Installed by hooks/install-hooks.sh. Bypass deliberately (and say why in
+# the commit message) with: git commit --no-verify
+set -uo pipefail
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "COMMIT BLOCKED: python3 not found; the lint gate cannot run." >&2
+  exit 1
+fi
+
+if [ ! -f scripts/lint_mantle.py ]; then
+  echo "COMMIT BLOCKED: scripts/lint_mantle.py is missing. Restore it from the" >&2
+  echo "starter pack — this hook exists because these failures are silent." >&2
+  exit 1
+fi
+
+python3 scripts/lint_mantle.py
+status=$?
+if [ $status -ne 0 ]; then
+  echo "" >&2
+  echo "COMMIT BLOCKED by lint_mantle.py (exit $status)." >&2
+  echo "Each finding above names its fix. The checks encode real, silent" >&2
+  echo "failures — fixing them now is cheaper than debugging them at train time." >&2
+fi
+exit $status

--- a/starter-pack/scripts/lint_mantle.py
+++ b/starter-pack/scripts/lint_mantle.py
@@ -1,0 +1,480 @@
+#!/usr/bin/env python3
+"""Static correctness checks for one Rasa Mantle project.
+
+Fast and offline: stdlib only, no network, no venv needed — safe as a
+pre-commit hook in a repo where nothing is installed yet. Run from the
+project root:
+
+    python3 scripts/lint_mantle.py
+    python3 scripts/lint_mantle.py --list
+    python3 scripts/lint_mantle.py --check agent-top-level-keys --check nested-if
+    python3 scripts/lint_mantle.py --json
+
+Every check encodes a failure a real Mantle project has actually hit
+(source: RasaHQ/rasa-community-resources, verified 2026-09-02 at
+rasa-pro 3.20.0.dev6). This layer answers "is the project internally
+consistent?" — only `rasa validate` / `rasa train` in a synced venv answers
+"does the engine accept it?". A green lint is necessary, not sufficient.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+ROOT = Path.cwd()
+
+# Prompt-tuning keys the engine reads ONLY from the top level of agent.yml.
+# `tool_timeout` arrived in 3.20.0.dev6; re-derive this list from the
+# installed engine after every version bump.
+TOP_LEVEL_AGENT_KEYS = (
+    "name",
+    "description",
+    "rules",
+    "conversation",
+    "references",
+    "before_end",
+    "tool_timeout",
+)
+
+# Keys that used to live inline under `llm:` and were removed in 3.20.0.dev6.
+INLINE_LLM_KEYS = ("provider", "model", "api_key_env", "api_key")
+
+SECRET_PATTERNS = (
+    ("OpenAI-style key", re.compile(r"sk-[A-Za-z0-9_\-]{20,}")),
+    ("JWT / licence", re.compile(r"eyJ[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-]{10,}\.")),
+)
+
+# Retired product names. Spelled in parts so this file passes its own check.
+RETIRED_TERMS = {"ma" + "estro": "Mantle"}
+
+SESSION_REF_RE = re.compile(r"(?<![\w.])session\.([\w-]+)\.([\w-]+)")
+MEMORY_TOKEN_RE = re.compile(r"@memory(?:\.[\w-]+)*")
+ENV_VAR_RE = re.compile(r"\$\{([A-Z][A-Z0-9_]*)\}")
+PRERELEASE_RE = re.compile(r"(a|b|rc|\.dev)\d*$")
+
+TEXT_GLOBS = ("*.md", "*.toml", "*.yml", "*.yaml", "*.py", "*.example", "Makefile")
+
+
+@dataclass
+class Finding:
+    check: str
+    path: str
+    line: int | None
+    message: str
+
+    def location(self) -> str:
+        return f"{self.path}:{self.line}" if self.line else self.path
+
+
+def _rel(path: Path) -> str:
+    try:
+        return path.relative_to(ROOT).as_posix()
+    except ValueError:
+        return str(path)
+
+
+def _files(*globs: str) -> list[Path]:
+    """Tracked files when git is available; a pruned filesystem walk otherwise."""
+    try:
+        out = subprocess.run(
+            ["git", "-C", str(ROOT), "ls-files", "-z", "--cached", "--others",
+             "--exclude-standard", *globs],
+            capture_output=True, text=True, check=True,
+        ).stdout
+        return [ROOT / p for p in out.split("\0") if p and (ROOT / p).is_file()]
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        skip = {".git", ".venv", "node_modules", "models", "__pycache__", ".rasa"}
+        found: list[Path] = []
+        for glob in globs or ("**/*",):
+            pattern = glob if "**" in glob or "/" in glob else f"**/{glob}"
+            for p in ROOT.glob(pattern):
+                if p.is_file() and not (set(p.parts) & skip):
+                    found.append(p)
+        return sorted(set(found))
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8", errors="replace")
+
+
+def _numbered(text: str):
+    return enumerate(text.splitlines(), start=1)
+
+
+# ------------------------------------------------------------------------------
+# checks
+# ------------------------------------------------------------------------------
+
+
+def check_agent_top_level_keys() -> list[Finding]:
+    """Prompt-tuning keys must sit beside `agent:`, never inside it.
+
+    The most expensive kind of regression: silent. Keys nested under `agent:`
+    parse without error and are then discarded — a real catalog carried 39
+    declared rules the engine never applied, found only by reading the built
+    prompt. The indent is derived from the file, so 4-space YAML can't slip
+    past a 2-space assumption.
+    """
+    findings: list[Finding] = []
+    for path in _files("agent.yml", "**/agent.yml"):
+        lines = _read(path).splitlines()
+        try:
+            start = next(i for i, l in enumerate(lines) if l.rstrip() == "agent:")
+        except StopIteration:
+            continue
+        child_indent = None
+        for i in range(start + 1, len(lines)):
+            line = lines[i]
+            if not line.strip():
+                continue
+            indent = len(line) - len(line.lstrip())
+            if indent == 0:
+                break
+            child_indent = indent
+            break
+        if child_indent is None:
+            continue
+        for i in range(start + 1, len(lines)):
+            line = lines[i]
+            if line.strip() and not line[0].isspace():
+                break  # a column-0 key ends the agent block
+            if ":" not in line or len(line) - len(line.lstrip()) != child_indent:
+                continue
+            key = line.strip().split(":", 1)[0]
+            if key in TOP_LEVEL_AGENT_KEYS:
+                findings.append(Finding(
+                    "agent-top-level-keys", _rel(path), i + 1,
+                    f"{key!r} is nested inside 'agent:', where the engine parses "
+                    f"it and then silently discards it. Move it to the top level "
+                    f"of agent.yml, as a sibling of 'agent:'.",
+                ))
+    return findings
+
+
+def check_llm_model_group() -> list[Finding]:
+    """`llm:` names a model group; provider settings live on the group.
+
+    3.20.0.dev6 made the LLM config extra="forbid" with a required
+    model_group. The inline form fails validate with
+    "'provider': Extra inputs are not permitted" — and every pre-dev6
+    example on the internet still shows the inline form.
+    """
+    findings: list[Finding] = []
+    for path in _files("integrations.yml", "**/integrations.yml"):
+        lines = _read(path).splitlines()
+        try:
+            start = next(i for i, l in enumerate(lines) if l.rstrip() == "llm:")
+        except StopIteration:
+            continue
+        saw_model_group = False
+        for i in range(start + 1, len(lines)):
+            line = lines[i]
+            if line.strip() and not line[0].isspace():
+                break
+            stripped = line.strip()
+            if stripped.startswith("#") or ":" not in stripped:
+                continue
+            key = stripped.split(":", 1)[0]
+            if key == "model_group":
+                saw_model_group = True
+            elif key in INLINE_LLM_KEYS:
+                findings.append(Finding(
+                    "llm-model-group", _rel(path), i + 1,
+                    f"{key!r} is set inline under 'llm:'. Since 3.20.0.dev6 the "
+                    f"orchestrator LLM is a model-group reference: use "
+                    f"'llm: {{model_group: <id>}}' and declare the provider under "
+                    f"a matching 'model_groups' entry.",
+                ))
+        if not saw_model_group:
+            findings.append(Finding(
+                "llm-model-group", _rel(path), start + 1,
+                "'llm:' does not name a model_group; validate will reject it "
+                "with \"'model_group': Field required\"",
+            ))
+    return findings
+
+
+def check_project_memory_writes() -> list[Finding]:
+    """Project-level memory is tool-written; the LLM may not set it.
+
+    3.20.0.dev6 rejects `llm_settable: true` on a root memory.yml field
+    outright. Skill-scoped memory (skills/<id>/memory.yml) is where the flag
+    belongs, so only root files are checked.
+    """
+    findings: list[Finding] = []
+    for path in _files("memory.yml"):
+        if path.parent != ROOT:
+            continue
+        for lineno, line in _numbered(_read(path)):
+            stripped = line.strip()
+            if stripped.startswith("#"):
+                continue
+            if re.match(r"^llm_settable:\s*true\b", stripped):
+                findings.append(Finding(
+                    "project-memory-writes", _rel(path), lineno,
+                    "project memory cannot be llm_settable — the engine rejects "
+                    "it. Have a tool write the field, or move it into "
+                    "skills/<id>/memory.yml.",
+                ))
+    return findings
+
+
+def _prose_lines(text: str):
+    """Yield (lineno, line) for skill.md text the LLM reads as prose.
+
+    Skips YAML frontmatter and `:::block ... :::` regions (those are YAML,
+    not prose). Top-level `if:` lines are conditions, also skipped.
+    """
+    lines = text.splitlines()
+    i = 0
+    if lines and lines[0].strip() == "---":
+        for j in range(1, len(lines)):
+            if lines[j].strip() == "---":
+                i = j + 1
+                break
+    in_block = False
+    while i < len(lines):
+        line = lines[i]
+        i += 1
+        stripped = line.strip()
+        if stripped.startswith(":::"):
+            in_block = not in_block and stripped != ":::"
+            continue
+        if in_block:
+            continue
+        if re.match(r"^if:\s*\S", line):
+            continue
+        yield i, line
+
+
+def check_nested_if() -> list[Finding]:
+    """`if:` only works at the top level of a skill body, never indented."""
+    findings: list[Finding] = []
+    for skill in _files("**/skill.md"):
+        for lineno, line in _numbered(_read(skill)):
+            if re.match(r"^[ \t]+if:\s*\S", line):
+                findings.append(Finding(
+                    "nested-if", _rel(skill), lineno,
+                    "indented 'if:' is not parsed as a condition; it stays "
+                    "instruction prose. Move the branch to the top level of the "
+                    "skill body, or express it in natural language.",
+                ))
+    return findings
+
+
+def check_skill_prose() -> list[Finding]:
+    """Skill prose must not contain raw `session.*` or partial @memory tokens."""
+    findings: list[Finding] = []
+    for skill in _files("**/skill.md"):
+        for lineno, line in _prose_lines(_read(skill)):
+            for match in SESSION_REF_RE.finditer(line):
+                findings.append(Finding(
+                    "skill-prose", _rel(skill), lineno,
+                    f"session.{match.group(1)}.{match.group(2)} appears in "
+                    f"instruction prose; it is not substituted there. Use "
+                    f"@memory.{match.group(1)}.{match.group(2)} or move it into "
+                    f"a top-level 'if:'.",
+                ))
+            for match in MEMORY_TOKEN_RE.finditer(line):
+                if len(match.group(0).split(".")) != 3:
+                    findings.append(Finding(
+                        "skill-prose", _rel(skill), lineno,
+                        f"{match.group(0)!r} is not a substitutable token; live "
+                        f"values require @memory.<namespace>.<entry>",
+                    ))
+    return findings
+
+
+def check_engine_version_pin() -> list[Finding]:
+    """The pin must be a pre-release the engine actually ships on.
+
+    The Mantle engine exists ONLY on the 3.20.0.dev line; the newest stable
+    rasa-pro ships no engine package at all. And 3.20 raised the Python floor
+    to 3.11 — a lower floor fails `uv lock` with a resolver error that never
+    mentions Python.
+    """
+    findings: list[Finding] = []
+    path = ROOT / "pyproject.toml"
+    if not path.is_file():
+        return [Finding("engine-version-pin", "pyproject.toml", None,
+                        "missing pyproject.toml")]
+    text = _read(path)
+    pin = re.search(r'"rasa-pro==([^"]+)"', text)
+    if not pin:
+        findings.append(Finding(
+            "engine-version-pin", _rel(path), None,
+            "no exact 'rasa-pro==<version>' pin found; an unpinned or ranged "
+            "dependency can resolve to a stable release with no engine package",
+        ))
+    elif not PRERELEASE_RE.search(pin.group(1)):
+        findings.append(Finding(
+            "engine-version-pin", _rel(path), None,
+            f"rasa-pro=={pin.group(1)} is a stable pin — stable releases ship "
+            f"no Mantle engine (verified against published wheels). Pin a "
+            f"3.20.0.dev release. Delete this check only when a stable release "
+            f"ships rasa.mantle.",
+        ))
+    if pin and PRERELEASE_RE.search(pin.group(1)):
+        if not re.search(r'prerelease\s*=\s*"allow"', text):
+            findings.append(Finding(
+                "engine-version-pin", _rel(path), None,
+                "pre-release pin without '[tool.uv] prerelease = \"allow\"' — "
+                "uv will refuse to resolve it",
+            ))
+    floor = re.search(r'requires-python\s*=\s*">=(\d+)\.(\d+)', text)
+    if floor and (int(floor.group(1)), int(floor.group(2))) < (3, 11):
+        findings.append(Finding(
+            "engine-version-pin", _rel(path), None,
+            f"requires-python floor {floor.group(1)}.{floor.group(2)} is below "
+            f"3.11; rasa-pro 3.20 needs >=3.11 and uv's resolver error will not "
+            f"mention Python",
+        ))
+    return findings
+
+
+def check_secret_hygiene() -> list[Finding]:
+    """No credentials committed, no .env tracked, .env gitignored."""
+    findings: list[Finding] = []
+    try:
+        tracked = subprocess.run(
+            ["git", "-C", str(ROOT), "ls-files", ".env", "**/.env"],
+            capture_output=True, text=True, check=True,
+        ).stdout.split()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        tracked = []
+    for p in tracked:
+        findings.append(Finding("secret-hygiene", p, None, ".env is tracked by git"))
+    gitignore = ROOT / ".gitignore"
+    if not gitignore.is_file() or ".env" not in _read(gitignore):
+        findings.append(Finding(
+            "secret-hygiene", ".gitignore", None,
+            "'.env' is not gitignored — one 'git add -A' away from publishing "
+            "credentials",
+        ))
+    for path in _files(*TEXT_GLOBS):
+        if path.name == "uv.lock":
+            continue
+        for lineno, line in _numbered(_read(path)):
+            for label, pattern in SECRET_PATTERNS:
+                if pattern.search(line):
+                    findings.append(Finding(
+                        "secret-hygiene", _rel(path), lineno,
+                        f"looks like a committed {label}",
+                    ))
+    return findings
+
+
+def check_env_example() -> list[Finding]:
+    """.env.example exists and names every key the config actually reads."""
+    findings: list[Finding] = []
+    example = ROOT / ".env.example"
+    if not example.is_file():
+        return [Finding(
+            "env-example", ".env.example", None,
+            "missing .env.example — a new user has no way to discover which "
+            "credentials this project needs",
+        )]
+    body = _read(example)
+    used: dict[str, str] = {}
+    for path in _files("*.yml", "**/*.yml", "*.yaml", "**/*.yaml"):
+        for match in ENV_VAR_RE.finditer(_read(path)):
+            used.setdefault(match.group(1), _rel(path))
+    pyproject = ROOT / "pyproject.toml"
+    if pyproject.is_file():
+        block = re.search(
+            r"required-secrets\s*=\s*\[([^\]]*)\]", _read(pyproject))
+        if block:
+            for name in re.findall(r'"([A-Z][A-Z0-9_]*)"', block.group(1)):
+                used.setdefault(name, "pyproject.toml required-secrets")
+    for var, where in sorted(used.items()):
+        if var not in body:
+            findings.append(Finding(
+                "env-example", ".env.example", None,
+                f"does not mention {var}, which is read by {where}; `cp "
+                f".env.example .env` produces a silently incomplete file and "
+                f"the failure surfaces later as an unexpanded ${{{var}}}",
+            ))
+    return findings
+
+
+def check_retired_brand() -> list[Finding]:
+    """Retired product names appear nowhere in content or paths.
+
+    Not cosmetics: `rasa init --engine <old-name>` sat in READMEs as a
+    copy-paste instruction after the CLI had narrowed to {calm,mantle} and
+    rejected it. A stale brand in a runnable command is a broken command.
+    """
+    findings: list[Finding] = []
+    for retired, replacement in RETIRED_TERMS.items():
+        pattern = re.compile(re.escape(retired), re.IGNORECASE)
+        for path in _files(*TEXT_GLOBS):
+            if path.name == "uv.lock":
+                continue
+            for lineno, line in _numbered(_read(path)):
+                if pattern.search(line):
+                    findings.append(Finding(
+                        "retired-brand", _rel(path), lineno,
+                        f"{retired!r} is retired; use {replacement!r}",
+                    ))
+            if pattern.search(_rel(path)):
+                findings.append(Finding(
+                    "retired-brand", _rel(path), None,
+                    f"path contains the retired name {retired!r}",
+                ))
+    return findings
+
+
+CHECKS = {
+    "agent-top-level-keys": check_agent_top_level_keys,
+    "llm-model-group": check_llm_model_group,
+    "project-memory-writes": check_project_memory_writes,
+    "nested-if": check_nested_if,
+    "skill-prose": check_skill_prose,
+    "engine-version-pin": check_engine_version_pin,
+    "secret-hygiene": check_secret_hygiene,
+    "env-example": check_env_example,
+    "retired-brand": check_retired_brand,
+}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true", help="Machine-readable output")
+    parser.add_argument("--check", action="append", default=[], metavar="NAME",
+                        help="Run only these checks (repeatable)")
+    parser.add_argument("--list", action="store_true", help="List check names and exit")
+    args = parser.parse_args()
+
+    if args.list:
+        print("\n".join(CHECKS))
+        return 0
+
+    selected = args.check or list(CHECKS)
+    unknown = [c for c in selected if c not in CHECKS]
+    if unknown:
+        print(f"Unknown check(s): {', '.join(unknown)}", file=sys.stderr)
+        return 2
+
+    findings: list[Finding] = []
+    for name in selected:
+        findings.extend(CHECKS[name]())
+
+    if args.json:
+        print(json.dumps({"findings": [asdict(f) for f in findings]}, indent=2))
+    else:
+        for f in findings:
+            print(f"[{f.check}] {f.location()}: {f.message}")
+        n = len(findings)
+        print(f"\n{'FAILED' if n else 'ok'} — {n} finding(s) "
+              f"across {len(selected)} check(s)")
+    return 1 if findings else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/starter-pack/scripts/lint_mantle.py
+++ b/starter-pack/scripts/lint_mantle.py
@@ -79,22 +79,42 @@ def _rel(path: Path) -> str:
         return str(path)
 
 
+# Directories whose contents are teaching material, not the project's own config.
+# A tutorial deliberately shows the OLD shape at step 0 and fixes it by step 3;
+# linting those snippets reports the lesson as a defect. The catalog's own
+# lint_repo.py never hits this because it reads exactly `<project>/integrations.yml`
+# rather than globbing, so this is the price of the recursive glob and has to be
+# paid explicitly.
+TEACHING_DIRS = {"snippets", "steps", "solutions", "before", "broken"}
+
+
+def _is_teaching(path: Path) -> bool:
+    return bool(set(path.parts) & TEACHING_DIRS)
+
+
 def _files(*globs: str) -> list[Path]:
-    """Tracked files when git is available; a pruned filesystem walk otherwise."""
+    """Tracked files when git is available; a pruned filesystem walk otherwise.
+
+    Teaching snippets are excluded from both paths — see TEACHING_DIRS.
+    """
     try:
         out = subprocess.run(
             ["git", "-C", str(ROOT), "ls-files", "-z", "--cached", "--others",
              "--exclude-standard", *globs],
             capture_output=True, text=True, check=True,
         ).stdout
-        return [ROOT / p for p in out.split("\0") if p and (ROOT / p).is_file()]
+        return [
+            ROOT / p
+            for p in out.split("\0")
+            if p and (ROOT / p).is_file() and not _is_teaching(Path(p))
+        ]
     except (subprocess.CalledProcessError, FileNotFoundError):
         skip = {".git", ".venv", "node_modules", "models", "__pycache__", ".rasa"}
         found: list[Path] = []
         for glob in globs or ("**/*",):
             pattern = glob if "**" in glob or "/" in glob else f"**/{glob}"
             for p in ROOT.glob(pattern):
-                if p.is_file() and not (set(p.parts) & skip):
+                if p.is_file() and not (set(p.parts) & skip) and not _is_teaching(p):
                     found.append(p)
         return sorted(set(found))
 


### PR DESCRIPTION
Built by the Sparring seat under direct operator retask (recorded at
`org-rasahq` PR #3). Opened by Master because `profrod-ai` is not a collaborator
here and cannot open PRs — see the identity finding below.

## What it is

A drop-in pack for anyone starting a Mantle project: 6 Claude Code skills,
2 roles (`mantle-builder`, `mantle-reviewer`), a `CLAUDE.md` carrying version
doctrine and the five silent traps, a stdlib-only 9-check `lint_mantle.py` that
runs in a bare repo pre-install, and pre-commit hooks.

Everything is distilled from this catalog at `3.20.0.dev6` — chiefly
`lint_repo.py`, `docs/MIGRATING.md` and the shipped tutorials — not from prior
memory of Rasa APIs, which predates the engine.

## Master review

I exercised the pack's own `mantle-reviewer` posture on it, as Sparring asked,
and reproduced its verification rather than accepting it.

**Confirmed:** the `.gitignore` negations are correct — none of the 13 shipped
pack files is ignored, and the seat overlay stays blocked. All 9 checks fire on a
synthetic trap project (14 findings). Catalog gate green, 97 tests.

**One defect found and fixed in `0f04010`.** Sparring sampled 2 shipped projects
and got 0 findings. I ran all 14 — and 2 **failed the pack's own lint**:

    [llm-model-group] tutorial/snippets/step-00-scaffold/integrations.yml:4:
    'provider' is set inline under 'llm:' ...

Those are teaching snippets. The tutorial deliberately shows the pre-dev6 inline
shape at step 0 and fixes it by step 3, so the lint was reporting the lesson as a
defect. A tool that flags shipped, gate-green projects would have been
switched off by the first user who tried it.

Cause: the pack globs `**/integrations.yml`, while the catalog's `lint_repo.py`
reads exactly `<project>/integrations.yml` and so never descends into snippets.
The recursive glob is right for a standalone tool that must work in a bare repo,
so the exclusion is paid explicitly via `TEACHING_DIRS`.

Re-verified both directions after the fix:

| | before | after |
|---|---|---|
| shipped catalog projects clean | 12/14 | **14/14** |
| checks firing on trap project | 9/9 | **9/9** |
| root `integrations.yml` still caught | yes | **yes** |

The last row matters: an identical bad file under `snippets/` is skipped while
the project's own root config is still caught, so this narrows scope without
blinding the check.

## Identity finding, for the record (F-E)

Sparring reports that git-over-SSH on this machine authenticates as
`matorclawson` for **every** seat — `seat use` switches the `gh` token but not
SSH — so its push rode Master's key despite pull-only API access. That is a third
identity channel beyond `gh` and `ZEO_SEAT`, and it means seat separation is
currently real for API calls and **not** real for pushes. Worth fixing with
per-seat SSH keys or HTTPS-token remotes before seat attribution is relied on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YAKn2Fc6rATu6zDAb6Z4ya