### PR TITLE
voice-router: keep the vendor catalogue true, and make its stated purpose real

### DIFF
--- a/patterns/voice-vendor-router/.env.example
+++ b/patterns/voice-vendor-router/.env.example
@@ -27,3 +27,10 @@ SPEECHMATICS_API_KEY=
 # ASR + TTS:                      https://portal.azure.com/
 # AZURE_SPEECH_API_KEY=
 # AZURE_SPEECH_REGION=
+# TTS (voicerouter.providers.elevenlabs): https://elevenlabs.io/
+# ELEVENLABS_API_KEY=
+# ASR (voicerouter.providers.assemblyai): https://www.assemblyai.com/
+# ASSEMBLYAI_API_KEY=
+# AWS Polly/Transcribe and Google Cloud use their own credential chains
+# (aws configure / Application Default Credentials), not .env keys.
+# Vosk, faster-whisper and NeuTTS are local: no credentials at all.

--- a/patterns/voice-vendor-router/scripts/probe_providers.py
+++ b/patterns/voice-vendor-router/scripts/probe_providers.py
@@ -79,7 +79,32 @@ def main() -> int:
             print(f"{YELLOW}Only one {kind.upper()} provider is configured — "
                   f"there is nothing to fail over to.{RESET}")
     print(f"{GREEN}Routing is live: {available['asr']} ASR, {available['tts']} TTS.{RESET}\n")
+
+    _print_shelf(inspector)
     return 0
+
+
+def _print_shelf(inspector: dict) -> None:
+    """Enumerate catalogued adapters this config does not use — the CATALOGUE's
+    stated purpose. Data only: nothing here imports a vendor or its SDK."""
+    from voicerouter.providers import CATALOGUE
+
+    configured = {
+        str(raw.get("name", ""))
+        for kind in ("asr", "tts")
+        for raw in ((inspector.get(kind) or {}).get("providers") or [])
+        if isinstance(raw, dict)
+    }
+    shelf = [e for e in CATALOGUE if e.dotted_path not in configured]
+    if not shelf:
+        return
+    print(f"{DIM}Also on the shelf — catalogued adapters this config does not use.")
+    print(f"Add one as a provider entry in integrations.yml to route through it:{RESET}")
+    for e in shelf:
+        live = "verified live" if e.verified_live else "unverified   "
+        print(f"  {e.kind}  {e.dotted_path:<48} {DIM}{e.env_var:<24} "
+              f"{live}  {e.note}{RESET}")
+    print()
 
 
 if __name__ == "__main__":

--- a/patterns/voice-vendor-router/tests/test_voicerouter.py
+++ b/patterns/voice-vendor-router/tests/test_voicerouter.py
@@ -331,5 +331,90 @@ class TestEngineContract(unittest.TestCase):
         self.assertEqual(contract.check(verbose=False), [])
 
 
+class TestVendorCatalogue(unittest.TestCase):
+    """CATALOGUE is data nothing imports at runtime — that is its point, and
+    also its risk. A typo'd dotted path or a renamed engine class would only
+    surface when a user configures that vendor, which is the worst time.
+    These tests keep the catalogue true in both directions, offline.
+    """
+
+    @staticmethod
+    def _bases():
+        from rasa.core.channels.voice_stream.asr.asr_engine import ASREngine
+        from rasa.core.channels.voice_stream.tts.tts_engine import TTSEngine
+
+        return {"asr": ASREngine, "tts": TTSEngine}
+
+    def test_every_catalogue_path_imports_and_matches_its_kind(self):
+        import importlib
+
+        from voicerouter.providers import CATALOGUE
+
+        bases = self._bases()
+        for entry in CATALOGUE:
+            with self.subTest(path=entry.dotted_path):
+                module_name, class_name = entry.dotted_path.rsplit(".", 1)
+                module = importlib.import_module(module_name)
+                cls = getattr(module, class_name)
+                self.assertTrue(
+                    issubclass(cls, bases[entry.kind]),
+                    f"{entry.dotted_path} is catalogued as {entry.kind!r} but "
+                    f"does not subclass {bases[entry.kind].__name__}",
+                )
+
+    def test_every_shipped_engine_is_catalogued(self):
+        """The other direction: an adapter added to providers/ without a
+        catalogue row is invisible to `make probe` and the docs."""
+        import importlib
+        import inspect
+        import pkgutil
+
+        import voicerouter.providers as pkg
+        from voicerouter.providers import CATALOGUE
+
+        bases = tuple(self._bases().values())
+        catalogued = {e.dotted_path for e in CATALOGUE}
+        missing = []
+        for info in pkgutil.iter_modules(pkg.__path__):
+            if info.name.startswith("_"):
+                continue  # shared machinery, not vendor surface
+            module = importlib.import_module(f"{pkg.__name__}.{info.name}")
+            for name, cls in inspect.getmembers(module, inspect.isclass):
+                if (
+                    cls.__module__ == module.__name__
+                    and issubclass(cls, bases)
+                    and cls not in bases
+                    and not name.startswith("_")
+                ):
+                    dotted = f"{module.__name__}.{name}"
+                    if dotted not in catalogued:
+                        missing.append(dotted)
+        self.assertEqual(
+            missing, [],
+            "shipped engine(s) absent from CATALOGUE - add a VendorEntry "
+            "so `make probe` and the docs can see them",
+        )
+
+    def test_every_catalogued_env_var_is_discoverable(self):
+        """An env var the catalogue names but .env.example never mentions is a
+        credential a reader has no way to discover."""
+        import re
+
+        from voicerouter.providers import CATALOGUE
+
+        example = (Path(__file__).resolve().parent.parent / ".env.example").read_text(
+            encoding="utf-8"
+        )
+        for entry in CATALOGUE:
+            if not re.fullmatch(r"[A-Z][A-Z0-9_]*", entry.env_var):
+                continue  # "(none — local)" and credential-chain notes
+            with self.subTest(env=entry.env_var):
+                self.assertIn(
+                    entry.env_var, example,
+                    f"{entry.env_var} (used by {entry.dotted_path}) is missing "
+                    f"from .env.example",
+                )
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
Follow-up from Sparring's post-merge review of the router (#14) and routed example (#18). The merged work is genuinely strong — 12 vendor adapters, a streaming-safe PCM converter, 33 offline tests, honest `verified_live` labeling. Three gaps found by descent, each verified against bytes before fixing:

1. **`CATALOGUE` had zero consumers.** Its docstring promises "`make probe` and the docs can enumerate them" — nothing read it (grepped the tree). `probe_providers.py` now prints catalogued adapters absent from your `integrations.yml`. The shipped config uses all 12 (verified: 12/12 name-match), so the section appears only on trimmed configs — exactly who needs it.
2. **`.env.example` was missing `ELEVENLABS_API_KEY` and `ASSEMBLYAI_API_KEY`** — credentials the adapters read via `os.environ` and the README mentions, undiscoverable from the template. Added, plus an explicit note that AWS/Google use credential chains and the local vendors need none.
3. **Nothing fenced any of it.** Three new `TestVendorCatalogue` tests assert offline, both directions: every dotted path imports and subclasses the engine base its `kind` claims; every shipped engine class is catalogued; every catalogued env var appears in `.env.example`. The env test **failed on the real gap** before fix 2 landed — fence verified on live prey.

**Also validated during this review:** the earlier feedback's ruleset claims (`required_approving_review_count: 1`, `dismiss_stale_reviews_on_push`, `require_last_push_approval`, merge-only) match the live ruleset byte-for-byte; `RasaAudioBytes(data, format=...)` matches the engine dataclass; `PcmStreamConverter` is used by `_http_tts` and `neuphonic` with per-utterance state as documented; router suite 36/36 in the project venv; root `make validate` green.

One self-correction on the record: this reviewer initially misread a diff's direction and briefly believed the local untracked drafts were *ahead* of main — they were stale precursors; main is the advanced version. Caught before filing by continuing the descent.

Authored by Sparring (`profrod-ai`); needs a second-party review + merge under the ruleset (`require_last_push_approval` — approve only after the last push, which is already in place; I will not push again unless review requests it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B9TWdwx7DsdoAaNGPKvKi8