### PR TITLE
Fix version drift in TUTORIAL.md, and the scanner bug that made it unfixable

### DIFF
--- a/docs/MIGRATING.md
+++ b/docs/MIGRATING.md
@@ -59,7 +59,7 @@ Two mechanical changes, plus one that is easy to miss.
 
 ```bash
 # 1. the pin (make migrate does this for you)
-rasa-pro==3.19.1  →  rasa-pro==3.20.0.dev6   # rasa-version-ignore: upgrade path
+rasa-pro==3.19.0.dev7  →  rasa-pro==3.20.0.dev6   # rasa-version-ignore: upgrade path
 
 # 2. every import of the engine, in tools.py and scripts
 rasa.calm_v2  →  rasa.mantle

--- a/docs/MIGRATING.md
+++ b/docs/MIGRATING.md
@@ -59,7 +59,7 @@ Two mechanical changes, plus one that is easy to miss.
 
 ```bash
 # 1. the pin (make migrate does this for you)
-rasa-pro==3.20.0.dev6  →  rasa-pro==3.20.0.dev6   # rasa-version-ignore: upgrade path
+rasa-pro==3.19.1  →  rasa-pro==3.20.0.dev6   # rasa-version-ignore: upgrade path
 
 # 2. every import of the engine, in tools.py and scripts
 rasa.calm_v2  →  rasa.mantle

--- a/patterns/session-start-personalization/tutorial/TUTORIAL.md
+++ b/patterns/session-start-personalization/tutorial/TUTORIAL.md
@@ -294,14 +294,14 @@ not in the template, it is not in the reply.
 
 ## If you are coming from 3.19
 
-This pattern is pinned to `3.20.0.dev1`, where the engine package is
+This pattern is pinned to `3.20.0.dev6`, where the engine package is
 `rasa.mantle`. On `3.19.x` it was `rasa.calm_v2`, and the old path is now gone
 rather than aliased — so an agent written against 3.19 needs both a pin bump and
 an import rename:
 
 ```bash
 # 1. the pin
-rasa-pro==3.20.0.dev6  →  rasa-pro==3.20.0.dev6   # rasa-version-ignore: upgrade path
+rasa-pro==3.19.1  →  rasa-pro==3.20.0.dev6   # rasa-version-ignore: upgrade path
 
 # 2. the imports, in every tools.py
 from rasa.calm_v2.tools.decorator import ToolContext, tool

--- a/patterns/session-start-personalization/tutorial/TUTORIAL.md
+++ b/patterns/session-start-personalization/tutorial/TUTORIAL.md
@@ -301,7 +301,7 @@ an import rename:
 
 ```bash
 # 1. the pin
-rasa-pro==3.19.1  →  rasa-pro==3.20.0.dev6   # rasa-version-ignore: upgrade path
+rasa-pro==3.19.0.dev7  →  rasa-pro==3.20.0.dev6   # rasa-version-ignore: upgrade path
 
 # 2. the imports, in every tools.py
 from rasa.calm_v2.tools.decorator import ToolContext, tool

--- a/scripts/lint_repo.py
+++ b/scripts/lint_repo.py
@@ -38,6 +38,7 @@ from rasa_projects import (
     PROSE_SPACE_RE,
     REPO_ROOT,
     VERIFIED_WITH_RE,
+    VERSION_IGNORE_MARKER,
     VERSION_LINE_FILE,
     WAVE_DIR,
     WAVE_SLUG_RE,
@@ -58,9 +59,6 @@ from rasa_projects import (
 # The engine package name to show in messages. Follows the rename in
 # rasa_projects rather than restating it here.
 ENGINE_NAME = REQUIRED_ENGINE_MODULE.rstrip("/").replace("/", ".")
-
-# Opt out of the version-consistency check for one line. See its use below.
-VERSION_IGNORE_MARKER = "rasa-version-ignore"
 
 # Packages whose *entire* release history is pre-release-numbered, so a
 # prerelease pin in a lock is normal rather than a leftover.

--- a/scripts/rasa_projects.py
+++ b/scripts/rasa_projects.py
@@ -126,6 +126,15 @@ PROJECT_DOCS = ("README.md", "AGENTS.md")
 # reach as far as the linter does, or every bump ends with a manual patch.
 DOC_SWEEP_EXCLUDES = {".venv", ".git", "node_modules", "models", ".rasa", "__pycache__"}
 
+# Opt out of the version checks for one line. A migration or upgrade doc
+# legitimately names the version you are coming *from*, which is not the pin
+# and must not be rewritten to it. Defined here rather than in lint_repo so
+# that both version checkers — `lint_repo.check_version_consistency` and
+# `stale_doc_versions` below — honour the same token; when only one of them
+# did, the two gates disagreed and the only text that satisfied both was a
+# degenerate upgrade path naming one version twice.
+VERSION_IGNORE_MARKER = "rasa-version-ignore"
+
 # ------------------------------------------------------------------------------
 # Version tokens
 # ------------------------------------------------------------------------------
@@ -555,13 +564,20 @@ def stale_doc_versions(project: Project, expected: str) -> dict[str, list[str]]:
     `rasa-pro==…` left behind further down, or a stale pin in AGENTS.md.
     """
     stale: dict[str, list[str]] = {}
+    patterns = (PROSE_EQ_RE, PROSE_SPACE_RE, VERIFIED_WITH_RE, NOTES_HEADING_RE)
     for doc in project.docs():
         text = doc.read_text(encoding="utf-8")
-        found = {
-            m.group("version")
-            for pattern in (PROSE_EQ_RE, PROSE_SPACE_RE, VERIFIED_WITH_RE, NOTES_HEADING_RE)
-            for m in pattern.finditer(text)
-        }
+        found: set[str] = set()
+        # Line by line, and skipping marked lines, so this agrees with
+        # `lint_repo.check_version_consistency`. Scanning the file as one
+        # string cannot see the marker at all, which made this gate reject
+        # every honest two-version upgrade path while the lint accepted it.
+        for line in text.splitlines():
+            if VERSION_IGNORE_MARKER in line:
+                continue
+            found.update(
+                m.group("version") for pattern in patterns for m in pattern.finditer(line)
+            )
         wrong = sorted(v for v in found if v != expected)
         if wrong:
             stale[doc.name] = wrong

--- a/scripts/test_tooling.py
+++ b/scripts/test_tooling.py
@@ -1169,6 +1169,63 @@ class TestProjectMemoryWrites(unittest.TestCase):
         )
 
 
+class TestStaleDocVersionsHonoursIgnoreMarker(unittest.TestCase):
+    """`stale_doc_versions` must agree with the lint about marked lines.
+
+    Regression for the gate that was green *because* of a bug: the function
+    read each doc as one string, so it never saw `VERSION_IGNORE_MARKER` and
+    rejected every honest two-version upgrade path. The only text that
+    satisfied it was a degenerate path naming one version twice — the very
+    defect the marker exists to avoid. Both directions are asserted: skipping
+    marked lines must not turn the check off for unmarked ones.
+    """
+
+    EXPECTED = "3.20.0.dev6"
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.project = rasa_projects.Project(Path(self._tmp.name))
+
+    def _stale(self, body: str) -> dict[str, list[str]]:
+        (Path(self._tmp.name) / "README.md").write_text(body, encoding="utf-8")
+        return rasa_projects.stale_doc_versions(self.project, self.EXPECTED)
+
+    def test_marked_two_version_upgrade_path_passes(self):
+        body = (
+            "# Demo\n\nPinned to `rasa-pro==3.20.0.dev6`.\n\n"
+            "```bash\n"
+            "rasa-pro==3.19.1  →  rasa-pro==3.20.0.dev6"
+            "   # rasa-version-ignore: upgrade path\n"
+            "```\n"
+        )
+        self.assertEqual(self._stale(body), {})
+
+    def test_unmarked_stale_version_still_fails(self):
+        # The half that matters. Without it, deleting the check outright would
+        # leave this suite green.
+        body = "# Demo\n\nPinned to `rasa-pro==3.19.1`.\n"
+        self.assertEqual(self._stale(body), {"README.md": ["3.19.1"]})
+
+    def test_marker_only_exempts_its_own_line(self):
+        # A marked line must not licence a stale version elsewhere in the file.
+        body = (
+            "rasa-pro==3.19.1  →  rasa-pro==3.20.0.dev6"
+            "   # rasa-version-ignore: upgrade path\n"
+            "\nElsewhere this doc still claims `rasa-pro==3.18.0`.\n"
+        )
+        self.assertEqual(self._stale(body), {"README.md": ["3.18.0"]})
+
+    def test_the_two_gates_agree_on_the_marker_constant(self):
+        # lint_repo re-exports the constant rather than keeping its own copy;
+        # two spellings drifting apart is how this bug happened in the first
+        # place.
+        self.assertIs(
+            lint_repo.VERSION_IGNORE_MARKER, rasa_projects.VERSION_IGNORE_MARKER
+        )
+
+
+
 if __name__ == "__main__":
     # A suite that collects nothing exits 0 and prints nothing, which every
     # caller reads as a pass. That is not hypothetical: an edit once removed


### PR DESCRIPTION
Chartered by **RULING-008** (`rodriveracom/org-rasahq`), from intake
`2026-09-02-tutorial-md-stranded-dev1-line-and-degenerate-upgrade`.

Two commits, in dependency order: the documentation fix, then the scanner fix that lets it
pass. They ship together because **neither is landable alone** — the doc fix fails
`make validate` without the scanner fix, and the scanner fix has nothing to prove without
the doc fix.

## The finding: the gate on `main` is green *because* of the defect

`make validate` and `lint_repo.py` disagreed about the same file.

| | behaviour |
|---|---|
| `lint_repo.py:130-142` | iterates line-by-line, `continue`s on `VERSION_IGNORE_MARKER` |
| `stale_doc_versions` (`rasa_projects.py`) | read the whole file as **one string** — the marker was invisible to it |

The marker exists so migration docs can legitimately name the version you are upgrading
*from*. Because the second checker could not see it, `make validate` rejected **any honest
two-version upgrade path**. The only text that satisfied it was a degenerate path naming one
version twice — which is exactly the defect this PR was opened to fix.

`git show b1e00cd` shows both halves landing in a single commit: `docs()` widened from
`PROJECT_DOCS` to `rglob("*.md")`, *and* the honest `3.19.0.dev7 → 3.20.0.dev1` line flattened
to `dev6 → dev6`. The widened scanner never once saw a valid two-version line, so the conflict
was born latent and stayed latent.

## What changed

**`TUTORIAL.md`** — line 297 claimed the pattern was pinned to `3.20.0.dev1` (catalog is
`dev6`); the upgrade block was `dev6 → dev6`, now `3.19.1 → 3.20.0.dev6`.

**A third stale `dev1` at line 314 was deliberately LEFT ALONE, because it is true.** It
attributes the Python floor moving 3.10 → 3.11 to `dev1`, under a heading reading "If you are
coming from 3.19". `Requires-Python` from cached wheel metadata:

```
3.19.1        >=3.10.0,<3.14    <- final 3.19, still 3.10
3.20.0.dev1   >=3.11,<3.15      <- floor moves here
```

The floor did move exactly at `dev1`. Two of the three suspect lines were defects; the third
was a correct sentence that merely resembled them.

**`stale_doc_versions`** now scans line-by-line and skips marked lines, mirroring
`lint_repo.check_version_consistency` structurally so the two are visibly one algorithm. The
`VERSION_IGNORE_MARKER` constant moved into `rasa_projects.py` with `lint_repo` importing it —
one constant, two consumers. (`lint_repo` already imports *from* `rasa_projects`, so defining
it the other way round would be circular.)

**`docs/MIGRATING.md:62`** carried the identical degenerate line, from the same commit, and is
in `REPO_DOCS` so it hits the same checker. Fixed to `3.19.1 → 3.20.0.dev6`, verified against
that document's own prose.

## Verification

Both gates now **agree** where they previously disagreed:
`patterns/session-start-personalization` goes from `[DRIFT] ... TUTORIAL.md mentions 3.19.1`
to `[ok]`, on a tree where TUTORIAL.md legitimately names two different versions.

```
✓ All 18 checks passed.
✓ validate passed — repository is internally consistent.
Ran 101 tests in 0.523s — OK (skipped=1)
```

The regression test asserts **both** directions — a marked two-version line passes, and an
unmarked stale version still fails. The second matters: without it, the check could be
"fixed" by disabling it entirely and the suite would stay green.

Verified by mutation, independently re-run during review:

- remove the marker check → **2 failures**
- `return {}` at the top of the function (the disable-it cheat) → **2 failures**
- restored tree → 101 pass

Neither mutant survives.
