### PR TITLE
heroes: scaffold wave-01-mantle before the Sept-20 submissions

### DIFF
--- a/heroes/README.md
+++ b/heroes/README.md
@@ -3,7 +3,9 @@
 Projects built by participants of the **Rasa Heroes** programme, organised by
 the cohort — the *wave* — that built them.
 
-This folder is **accepting waves**. No cohort has landed yet.
+This folder is **accepting waves**. The open cohort is
+[**wave-01-mantle**](wave-01-mantle/README.md) — the first cohort on the Mantle
+engine — and it is accepting projects now.
 
 A wave is a fixed group of people working over a fixed period on a shared theme.
 The point of keeping their work here rather than scattered across forks is that
@@ -18,7 +20,7 @@ version, all credited by name.
 heroes/
   README.md                      this page — the index of every wave
   WAVE_TEMPLATE.md               copy this into a new wave's README.md
-  wave-01-<theme>/
+  wave-01-mantle/                the open cohort
     README.md                    the wave charter: dates, theme, stewards, projects
     projects/
       <participant-handle>-<project-slug>/
@@ -30,8 +32,8 @@ heroes/
 ```
 
 Wave slugs are `wave-NN-<theme>`, zero-padded, so the directory listing and the
-chronological order are the same thing: `wave-01-voice`, `wave-02-tools`,
-`wave-10-observability`. `make validate` enforces the shape — a project filed
+chronological order are the same thing: `wave-01-mantle`, `wave-02-<theme>`,
+`wave-10-<theme>`. `make validate` enforces the shape — a project filed
 anywhere other than `<wave>/projects/<project>/` is invisible to every check,
 which is exactly the failure worth catching at review time rather than a year later.
 
@@ -58,9 +60,10 @@ no secrets in it. Full contract: [`docs/SNAPSHOTS.md`](../docs/SNAPSHOTS.md).
 
 | Wave | Theme | Period | Participants | Charter |
 |---|---|---|---|---|
-| — | — | — | — | — |
+| `wave-01-mantle` | First cohort on the Mantle engine | TBD | TBD | [charter](wave-01-mantle/README.md) |
 
-_No waves yet._
+_One wave, open. `wave-01-mantle` has its period, stewards and roster marked TBD
+until the programme announces them — they are not estimated here._
 
 ---
 

--- a/heroes/wave-01-mantle/README.md
+++ b/heroes/wave-01-mantle/README.md
@@ -1,0 +1,71 @@
+# Wave 01 — First cohort on the Mantle engine
+
+```text
+Wave:          wave-01-mantle
+Period:        TBD — not yet announced
+Stewards:      TBD — not yet announced
+Rasa Pro:      3.20.0.dev6 — the version this cohort built against
+Participants:  TBD — roster not yet final
+```
+
+The first Rasa Heroes cohort, and the first group to build on the **Mantle**
+engine rather than on the CALM-era stack that preceded it. The wave exists
+because Mantle changed what a Rasa project looks like from the first command
+onwards, and no amount of reference documentation substitutes for a set of real
+projects, built independently, by people meeting the engine for the first time.
+What this cohort produces is therefore a record of where a newcomer to Mantle
+actually gets stuck — which is the thing the documentation cannot tell us about
+itself.
+
+This charter is **open and accepting projects.** Submissions land by
+**2026-09-20.** The period, the stewards and the participant roster are marked
+TBD above because they are not settled yet; they are filled in here, not
+guessed at, once the programme announces them. Nothing below has been
+back-dated or estimated.
+
+## Theme
+
+**In scope:** anything built on the Mantle engine at `rasa-pro 3.20.0.dev6` —
+voice or text, a full agent or a single pattern worth reusing. The shared
+constraint is the engine and the pin, not the domain.
+
+**Explicitly not in scope:** projects built on the CALM-era stack, and projects
+that cannot be reproduced from what is committed. A wave project is a frozen,
+dated record, so it has to run from its own `uv.lock` and its own
+`.env.example` without private setup.
+
+## Participants
+
+The roster is not final. Each participant adds their own row here in the same
+pull request that adds their project.
+
+| Participant | GitHub | Project |
+|---|---|---|
+| _TBD — roster not yet announced_ | — | — |
+
+## Projects
+
+No projects have landed yet. This wave is open.
+
+| Project | What it does | Author | Verified with | Assessed on |
+|---|---|---|---|---|
+| _none yet_ | — | — | — | — |
+
+Every project directory under `projects/` must appear in this table — the build
+fails otherwise, because an unlisted project is one nobody can find. Adding a
+directory and adding its row here are one pull request, never two.
+
+## What this cohort found
+
+Not yet written. This section is filled in when the wave closes, not while it
+is running — a findings list assembled in advance is a plan, not a finding.
+
+It should end up as three to six specific bullets: what worked, what did not,
+what surprised people, and what the next wave should not repeat. A wave that
+learned something negative is more useful than one that reports only successes.
+
+## Frozen
+
+These projects are pinned to `rasa-pro 3.20.0.dev6` and are not migrated
+forward. See [`docs/SNAPSHOTS.md`](../../docs/SNAPSHOTS.md) for what that
+guarantees and what it does not.

--- a/heroes/wave-01-mantle/projects/README.md
+++ b/heroes/wave-01-mantle/projects/README.md
@@ -1,0 +1,23 @@
+# wave-01-mantle projects
+
+Nothing has landed here yet. Each participant project in this wave is one
+directory at this level:
+
+```text
+heroes/wave-01-mantle/projects/<your-handle>-<project-slug>/
+  README.md          metadata block: Author, Wave, Assessed on, Assessed by, Verified with
+  pyproject.toml     pins the rasa-pro version you verified against
+  uv.lock            committed, and matching that pin
+  .env.example       no secrets, only the key names your project needs
+  …
+```
+
+Add your project's row to the [wave charter](../README.md) in the same pull
+request that adds the directory. A directory with no row fails `make validate`,
+because an unlisted project is one nobody can find.
+
+Full contract for a frozen wave project: [`docs/SNAPSHOTS.md`](../../../docs/SNAPSHOTS.md).
+
+This file exists only so the empty `projects/` directory can be committed
+before the first project arrives; it is not itself a project and no check
+discovers it.


### PR DESCRIPTION
Chartered by **RULING-012 §s2**. **Deadline-bound: external submissions land 2026-09-20.**

## Why this was urgent, mechanically

`heroes/` shipped a `WAVE_TEMPLATE.md` and **no wave directory**, with `heroes/README.md`
saying *"This folder is accepting waves. No cohort has landed yet."*

`scripts/rasa_projects.py:107` enforces `WAVE_SLUG_RE = ^wave-\d{2}-[a-z0-9]+(?:-[a-z0-9]+)*$`.
So N contributors arriving to an empty `heroes/` each invent a slug — and **the trunk gate goes
red on arrival**, in public, in front of the people we are trying to welcome. Creating the
directory first is the entire fix.

Theme chosen by the operator: **`wave-01-mantle`** — "first cohort on the Mantle engine".

## Nothing was invented

Four fields are marked **TBD** because they are not settled: period, stewards, participant
count, participant roster. The README says explicitly that they are TBD *because unsettled*,
and that nothing was back-dated or estimated — so a contributor cannot misread a blank as an
oversight. Two sections are honestly deferred rather than faked: **Projects** is `_none yet_`,
and **What this cohort found** states it is written when the wave closes, because *"a findings
list assembled in advance is a plan, not a finding."*

The only date stated is the `2026-09-20` submission deadline, which came from the charter.

`Rasa Pro: 3.20.0.dev6` was verified against `RASA_PRO_VERSION` rather than trusted. Zero
template placeholders remain (`<Theme>`, `wave-NN`, `YYYY-MM-DD`, `handle-project-slug`,
`X.Y.Z`, `@handle` — all scanned, all clean).

## The submitter path is proven in both directions

A layout check nobody has seen fail is not known to work (RULING-010). Reproduced during
review, not accepted on report:

**Directory present, table row missing → the gate FAILS:**
```
✗ heroes/wave-01-mantle/README.md
    does not mention 'mc-probe'; add its catalog row in the same pull request
    that adds the directory
```

Removed the probe → `✓ All 18 checks passed`, tree clean. The message is actionable and names
the fix, which is what a first-time contributor needs at exactly that moment.

## `projects/` placeholder: a README, not a `.gitkeep`

Git cannot commit an empty directory. The stream chose a short `projects/README.md` over a
`.gitkeep` because *"the first thing a contributor does is open the directory they are supposed
to file into"* — and it states the required shape plus the rule that the directory and its table
row go in **one** pull request. It carries no `pyproject.toml`, so `discover_projects` skips it
and it is never mistaken for a project.

## Three findings from the stream

1. **The charter mis-attributed the enforcing check.** It is `index-rows`, not
   `check_heroes_layout` — the latter only validates the slug, the wave README's presence, and
   the programme-index listing; it never inspects the projects table. Enforcement is real (seen
   to fail), it just lives elsewhere. Anyone debugging a red submission gate should grep for
   `index-rows`.
2. **`WAVE_TEMPLATE.md` is written entirely for a *completed* wave** — past tense throughout,
   with "What this cohort found" required and both tables carrying example rows. It offers no
   sanctioned way to say "not yet", which is precisely the state that matters when scaffolding.
   **That shape is why a steward would be tempted to invent a period.** One line permitting
   `TBD` would fix it. Not changed here (the charter forbade template edits); filed as a
   finding.
3. **`heroes/README.md` contained two statements this change made false** beyond the status
   line: the layout block showed `wave-01-<theme>/` as a literal and the prose gave
   `wave-01-voice` as the example slug. Corrected minimally — shipping a model file that
   contradicts the directory beside it would teach the wrong slug to every contributor who
   copies it.

## Gates

```
✓ All 18 checks passed.
✓ validate passed — repository is internally consistent.
```
Both were green on the untouched worktree first, so the passes are attributable to this change.
