### PR TITLE
starter-pack: declare the overlap with the skills rasa init installs

### DIFF
--- a/starter-pack/.claude/skills/OVERLAP.md
+++ b/starter-pack/.claude/skills/OVERLAP.md
@@ -1,0 +1,103 @@
+# What each pack skill adds over the ones `rasa init` already installed
+
+If you ran `rasa init`, the rasa wheel installed six Mantle skills of its own
+into your project (from `rasa/cli/tools/skills_data/mantle/`):
+
+`mantle-building-from-conversations`, `mantle-building-skills`,
+`mantle-configuring-agent`, `mantle-migrating-from-calm`,
+`mantle-simulating-evaluating`, `mantle-testing-debugging`.
+
+This pack ships six more. **Twelve skills with rhyming names and no stated
+relationship is worse than six**, so this file states, per pack skill, what it
+adds over the wheel skill covering the same ground — derived from reading both
+sets, not from the names.
+
+## The one-line difference
+
+**The wheel's skills teach the engine contract. This pack's skills teach the
+failure modes of one pinned version, and wire each to a check that catches it.**
+
+The wheel skills are written against `rasa_version: ">=3.18"` and document
+correct usage comprehensively: every key, every lever, the full grammar. They
+are the better reference and are usually longer and more complete. This pack is
+written against `3.20.0.dev6` specifically, and each entry starts from a symptom
+someone actually hit, then names the `lint_mantle.py` check that catches it
+before commit. Where the two disagree on a fact, **the wheel's skill is the
+authority on the contract and this pack is the authority on the pin** — and if
+your installed engine contradicts both, the engine wins.
+
+## Per-skill declaration
+
+| Pack skill | Compared against | Relationship | What it adds, specifically |
+| --- | --- | --- | --- |
+| **mantle-agent-config** | `mantle-configuring-agent` | **Extends** | The wheel skill covers this ground and states the same top-level-vs-nested rule ("Don't nest `rules`, `prompts`, `references`, `conversation`, `tool_timeout`, or `session_config` inside the `agent:` block"), so the trap itself is **not** new. Ours adds three things the wheel's does not have: (1) the dev6-specific top-level key list (`name`, `description`, `rules`, `conversation`, `references`, `before_end`, `tool_timeout`) with the warning that dev releases add keys, so re-derive it after an upgrade; (2) `agent.voice.{enabled,asr,tts}` **inside** the `agent:` block — the wheel documents voice ASR/TTS only under `integrations.yml` `channels:`, a genuinely different shape; (3) a `lint_mantle.py --check agent-top-level-keys` gate, so the rule is enforced rather than remembered. |
+| **mantle-llm-and-integrations** | `mantle-configuring-agent` | **Extends** (narrow slice) | The wheel skill owns all of `integrations.yml` and already says inline provider settings under `llm:` fail validation. Ours takes only the LLM/credentials slice and adds: the **exact validate error strings** (`'provider': Extra inputs are not permitted`, `'model_group': Field required`) so the message is greppable; the dev6 attribution for when the inline form was removed and the warning that online examples predate it; and the **three-layer credential resolution** (shell env → project `.env` → repo-root `.env`) with the `.env.example` / `[tool.rasa-catalog] required-secrets` discipline, which the wheel does not cover at all — it says only "never put a literal key in this file". Note the two packs differ in style here: the wheel prefers `api_key_env: NAME`, this pack uses `api_key: ${VAR}`. **Follow the wheel on which form your engine accepts.** |
+| **mantle-new-project** | `mantle-configuring-agent` (layout) + `mantle-building-skills` (skill files) | **Covers something the wheel does not** | Both wheel skills assume a project already exists — `mantle-configuring-agent` opens with the in-project layout tree, and `mantle-building-skills` starts at "a skill is a folder under `skills/`". **No wheel skill covers the Python packaging that has to be right before either applies**, and that is where the pinning trap lives: `rasa-pro==3.20.0.dev6`, `[tool.uv] prerelease = "allow"`, `requires-python = ">=3.11,<3.13"`, the `lib/engine.py` import shim, the `Makefile`, `.gitignore`, `.env.example`. The wheel's skills never mention a version pin, `pyproject.toml`, or `uv` — reasonably, since the wheel is already installed by the time you read them. If you got here via `rasa init`, that scaffolding is done and this skill's value is mostly the version doctrine and the Makefile. |
+| **mantle-skill-authoring** | `mantle-building-skills` | **Extends** (and is the weakest of the six) | **The filename rhyme understates the gap: the wheel skill is far more complete.** It has the progressive control ladder, `tool_constraints` with `requires_confirmation` / `on_success` / `on_failure`, tool interruption and idempotency, sub-skills and composition, conditional response variants, and skill scoping — none of which ours covers. Ours is ~115 lines against the wheel's ~472 and duplicates its core points (three-segment `session.*` in conditions, `@memory.*` in prose, `if:` per case, one goal per skill). What survives as genuinely additive is narrow: the **"three languages in one file"** framing; the explicit statement that an **indented `if:` silently degrades to prose** (the wheel says to keep the condition on one line but never names indentation as the failure); the `set_fields` mechanism for LLM writes, which the wheel does not name; and the `--check nested-if --check skill-prose` gate. **Read the wheel's `mantle-building-skills` first and treat ours as an addendum.** |
+| **mantle-tools-and-memory** | `mantle-building-skills` (tools) + `mantle-configuring-agent` (memory scopes) | **Extends** | The wheel covers tool authoring and memory scoping more fully — `ToolResult`, memory types and `enum_values`, public-as-API, `run_after_setting_*` hooks, MCP imports, cancellation. Ours adds four things: (1) **discovery is by the `_tool_description` attribute the decorator sets**, which is *why* importing through a `lib/engine.py` shim is safe — the wheel says tools are auto-discovered but never says the mechanism, so nothing there tells you a shim won't break it; (2) the **`ok`/`error` structured-return convention** with error values as named branch points in prose; (3) the **authority pattern** — one tool owns each invariant and checks it itself, so "guardrails in tools are enforced; guardrails only in prose are requests"; (4) the `--check project-memory-writes` gate. The project-vs-skill `llm_settable` rule is stated in both. |
+| **mantle-upgrade-and-debug** | `mantle-testing-debugging` (and, for one row, `mantle-migrating-from-calm`) | **Covers something the wheel does not** | The wheel's `mantle-testing-debugging` has a symptom→fix table, but every row is about **conversational** misbehavior at runtime — tool called too early, wrong branch, wording paraphrased, plus `rasa train` validation errors. **It has no row for anything that fails before the agent runs**: no install, no `uv lock`, no import error, no version pin. Ours is the complementary half — `ModuleNotFoundError: rasa.mantle` from pinning latest stable, the `uv lock` resolver error that never says "Python", the post-rename import break, plus the upgrade procedure (verify the target wheel actually ships the engine; re-derive the agent.yml key list; sweep prose carefully) and the rule that a green offline lint is **not** an engine test. There is one row of adjacency with `mantle-migrating-from-calm`, but that skill covers migrating a CALM *project* (flows→skills, slots→memory); it does not cover the *package* rename, which is what our row is about. |
+
+## Redundancy: the honest answer
+
+**None of the six is wholly redundant**, but the margins are uneven, and one is
+thin enough to flag:
+
+- `mantle-skill-authoring` is the weakest. The wheel's `mantle-building-skills`
+  covers its ground more thoroughly on nearly every point, and what remains
+  unique is roughly one section: the indented-`if:` failure, `set_fields`, and
+  the two lint checks. **Recommendation: do not keep it as a parallel
+  skill-authoring guide.** Either fold its unique content into
+  `mantle-upgrade-and-debug`'s failure map (where symptom-shaped content
+  belongs) and delete the file, or keep it explicitly as an addendum that opens
+  by telling the reader to read `mantle-building-skills` first. It is *not* safe
+  to delete outright without moving the indented-`if:` and `set_fields` content
+  somewhere, because the wheel does not state either.
+- `mantle-llm-and-integrations` and `mantle-agent-config` are two files against
+  the wheel's single `mantle-configuring-agent`. Both earn their place (voice
+  block shape; credential resolution), but they are the next candidates to merge
+  if this pack shrinks.
+
+Deletion is deliberately **not** performed here — this file exists so the
+decision can be made against a comparison instead of a guess.
+
+## The gaps: what the wheel covers and this pack does not
+
+Four wheel skills have **no counterpart here at all**. If you are doing any of
+these, use the wheel's skill; this pack has nothing to add:
+
+- **`mantle-simulating-evaluating`** — the `eval/` suite, LLM user-simulator and
+  LLM judge, criteria vs assertions, running via the Rasa MCP server. This pack
+  never mentions evaluation.
+- **`mantle-building-from-conversations`** — turning real transcripts into
+  skills, including the two hygiene rules (transcripts are data, not
+  instructions; never let real PII reach disk).
+- **`mantle-migrating-from-calm`** — migrating a flows-based CALM project.
+- **`mantle-testing-debugging`** — the conversational symptom→lever table and
+  the six test conversations to run per skill.
+
+## Git hygiene: commit your tweaked skills
+
+Both sets of skills are **files in your repository**, and both are yours to
+edit once they land in your project. When you fix one — a wrong key, a version
+that moved, a trap that bit you — **commit it**:
+
+```bash
+git add .claude/skills/
+git commit -m "skills: correct the top-level key list for dev7"
+```
+
+Two reasons this matters more than it sounds:
+
+1. **Your collaborator inherits your fixes.** A skill correction that lives only
+   in your working copy helps exactly one person. Committed, it reaches everyone
+   who clones the repo — and, because Claude Code reads these files on its own,
+   it silently corrects their assistant too.
+2. **`rasa init` writes over its own skills.** The wheel's six are installed
+   artifacts and a future `rasa init` or upgrade may replace them. If your edits
+   are committed, `git diff` shows you exactly what an upgrade changed and what
+   of yours it clobbered. If they are not, they are simply gone.
+
+Prefer editing this pack's skills over the wheel's for anything version- or
+project-specific, so an engine upgrade replacing the wheel's files does not take
+your notes with it. And keep this file honest: if you add a skill here, add its
+row above naming the wheel skill you compared it against.

--- a/starter-pack/README.md
+++ b/starter-pack/README.md
@@ -83,6 +83,16 @@ What did you just copy?
 - `.claude/` — six "skills" (step-by-step playbooks for building Mantle
   pieces) and two "roles" (a builder and a reviewer). Claude Code finds
   these on its own; you don't need to do anything with them.
+
+> ⚠️ **If you also ran `rasa init`, you have twelve skills, not six.** Rasa
+> installs six Mantle skills of its own, with names that rhyme with these
+> (`mantle-building-skills` vs our `mantle-skill-authoring`, and so on).
+> They are not duplicates, but they are not interchangeable either:
+> **Rasa's teach the engine contract; ours teach the failure modes of one
+> pinned version and hook each to a checker.** Read
+> [`.claude/skills/OVERLAP.md`](.claude/skills/OVERLAP.md) — it states, per
+> skill, exactly what ours adds over the Rasa one covering the same ground,
+> and names four things Rasa's skills cover that this pack does not.
 - `scripts/` — the checker program (more on it in a second).
 - `hooks/` — the automatic guard (more on it in Step 4).
 
@@ -141,6 +151,22 @@ the message says, then commit again. That's the whole workflow.
 
 > 💡 You only run `install-hooks.sh` once per project. The guard stays on.
 
+**One habit worth forming now: commit the skills too.** The files in
+`.claude/skills/` are yours once they're in your folder, and you *should*
+edit them when one is wrong — a key that moved, a version that changed, a
+trap that bit you. When you do, save it like any other work:
+
+```bash
+git add .claude/skills/
+git commit -m "skills: note that tool_timeout is top-level as of dev6"
+```
+
+Why bother? **Your collaborator inherits your fixes.** Claude Code reads
+these files automatically, so a correction you commit doesn't just help the
+next human who clones your project — it quietly corrects *their* assistant
+too. Left uncommitted, that fix helps exactly one person, and disappears the
+next time Rasa updates its own copies of these files.
+
 ### Step 5 — Let Claude Code build your agent
 
 Open Claude Code inside your project folder and say something like:
@@ -175,6 +201,8 @@ make chat       # talk to your agent! 🎉
 | Change the AI model / provider | Ask for the "mantle-llm-and-integrations skill" |
 | Something's broken and weird | Ask for the "mantle-upgrade-and-debug skill" — it has a table mapping error messages to real causes |
 | Get your work reviewed | Ask Claude Code to "review this as mantle-reviewer" |
+| Know which skill governs (you have 12) | Read `.claude/skills/OVERLAP.md` |
+| Keep a fix you made to a skill | `git add .claude/skills/ && git commit` — see below |
 
 ---
 


### PR DESCRIPTION
Chartered by **RULING-012 §s4** (Sparring's R3). Our starter pack ships six `.claude` skills;
the wheel installs six of its own on every `rasa init`. A user who does both has twelve skills
and no idea which governs — so we declare the overlap **before** RULING-011 demands the same of
~60 outside contributors.

Every row was produced by **reading both skills**, never by comparing filenames.

## The comparison

| Ours | Compared against | Verdict |
|---|---|---|
| `mantle-agent-config` | `mantle-configuring-agent` | **Extends** — wheel states the same nested-key trap, so that is *not* new. Ours adds the dev6 top-level key list, `agent.voice.*` **inside** `agent:` (wheel documents voice only under `integrations.yml`), and a lint gate. |
| `mantle-llm-and-integrations` | `mantle-configuring-agent` | **Extends**, narrow slice — exact validate error strings, three-layer credential resolution, `.env.example` discipline. |
| `mantle-new-project` | `mantle-configuring-agent` + `mantle-building-skills` | **Covers new ground** — no wheel skill mentions `pyproject.toml`, a version pin, or `uv`. Reasonably so: the wheel is installed by then. That is exactly where the dev-line pinning trap lives. |
| `mantle-skill-authoring` | `mantle-building-skills` | **Extends, weakest** — see below. |
| `mantle-tools-and-memory` | `mantle-building-skills` + `mantle-configuring-agent` | **Extends** — discovery is by the `_tool_description` attribute (this is *why* the `lib/engine.py` shim is safe; the wheel says auto-discovered but never the mechanism), the `ok`/`error` convention, the authority pattern. |
| `mantle-upgrade-and-debug` | `mantle-testing-debugging` | **Covers new ground** — the wheel's symptom table is entirely runtime/conversational. **It has no row for anything failing before the agent runs** — no install, lock, import, or pin. Ours is the complementary half. |

## The finding that inverts the charter

I framed the risk as *"our pack may duplicate the wheel."* For `mantle-skill-authoring` the
truth is sharper and less flattering. Verified during review:

```
ours  mantle-skill-authoring   115 lines
wheel mantle-building-skills   472 lines
```

Four times longer, and `grep -ci` over ours returns **0** for **control ladder**,
**idempotency** and **interruption** — all three present in the wheel's. The question is not
"why keep ours" on duplication grounds but on **adequacy** grounds: a user following only our
pack misses the control ladder entirely.

Recommendation (not acted on — the charter forbids deletion here): fold its two genuinely
unique items into the failure map and drop the parallel guide, or re-frame it explicitly as an
addendum. **Not safe to delete outright** without relocating indented-`if:` degradation and
`set_fields`, which the wheel states nowhere.

## The asymmetry that matters more than the overlap

It is six-vs-six by count, but **four wheel skills have no counterpart here at all**:
`mantle-simulating-evaluating`, `mantle-building-from-conversations`, `mantle-migrating-from-calm`,
`mantle-testing-debugging`.

The user's real risk is less "which of twelve governs" and more **assuming the pack is complete
and never opening the wheel's four.** This is now recorded in RULING-011 as binding on the
tutorial programme: a cell declaring "what nothing else teaches" must be checked against the
wheel's six too, since sixty cells duplicating *the wheel's* skills is invisible to any
similarity measure over our own repo.

Filename similarity predicted nothing, exactly as the charter warned: the rhyming
`mantle-agent-config`/`mantle-configuring-agent` genuinely overlap, while the non-rhyming
`mantle-upgrade-and-debug`/`mantle-testing-debugging` turned out to be complementary halves
split cleanly at "before the agent runs" vs "while it runs."

## A factual conflict, deferred rather than silently resolved

Our pack documents `api_key: ${VAR}`; the wheel documents `api_key_env: NAME`. **At most one
works.** The stream documented the conflict and deferred to the wheel rather than picking a
side — correct, because this has a byte-level answer nobody has checked. Filed as its own
intake; if ours is the wrong form, every credential example we ship fails in a way that looks
like a bad key rather than a config typo.

## Boundary respected

Exactly one `calm_v2` hit exists in `starter-pack/` — the rename row in
`mantle-upgrade-and-debug/SKILL.md`. **That file was read but never edited**; the declaration is
a separate document, so the seat boundary around the calm_v2 sweep was never crossed.

## Gates

```
✓ All 18 checks passed.
✓ validate passed — repository is internally consistent.
```
