### PR TITLE
hubspot: keep the MCP promise — instructions survive the transport

### DIFF
--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -41,6 +41,7 @@ If a tutorial is the companion to an example in `examples/`, say so in both READ
 |---|---|---|---|---|
 | Atlas voice agent tutorial | Atlas | Horizon Travel | [`rasa-voice-agent-tutorial`](rasa-voice-agent-tutorial) | 2026-08-13 |
 | Guarding an irreversible action | Wren | Northgate Bank | [`rasa-card-reissue-tutorial`](rasa-card-reissue-tutorial) | 2026-09-02 |
+| Ora on HubSpot CRM, and the same agent over MCP | Ora | Meridian | [`rasa-hubspot-crm-tutorial`](rasa-hubspot-crm-tutorial) | 2026-09-02 |
 
 When you add a tutorial, append a row here in the same PR.
 

--- a/tutorials/rasa-hubspot-crm-tutorial/.gitignore
+++ b/tutorials/rasa-hubspot-crm-tutorial/.gitignore
@@ -4,3 +4,6 @@ models/
 __pycache__/
 *.pyc
 .venv/
+
+# Transport swap leaves these behind while `make mcp-swap` is active.
+*.rest

--- a/tutorials/rasa-hubspot-crm-tutorial/Makefile
+++ b/tutorials/rasa-hubspot-crm-tutorial/Makefile
@@ -11,7 +11,8 @@ UV     := $(shell command -v uv 2>/dev/null)
 PYTHON ?= python3
 
 .DEFAULT_GOAL := help
-.PHONY: help check-uv env guard-env install mock train chat run crm-check clean
+.PHONY: help check-uv env guard-env install mock train chat run crm-check clean \
+        mcp-server mcp-prove mcp-swap mcp-restore mcp-status
 
 help: ## Show this help message
 	@echo ''
@@ -24,6 +25,14 @@ help: ## Show this help message
 	@echo '  $(GREEN)make chat$(RESET)       Talk to the agent in the Inspector'
 	@echo '  $(GREEN)make crm-check$(RESET)  Call the CRM directly and print what comes back'
 	@echo '  $(GREEN)make clean$(RESET)      Remove models and caches'
+	@echo ''
+	@echo '$(YELLOW)The MCP chapter — same skills, different transport$(RESET)'
+	@echo ''
+	@echo '  $(GREEN)make mcp-prove$(RESET)   Prove the swap. No licence, no key, no account.'
+	@echo '  $(GREEN)make mcp-swap$(RESET)    Move the project onto MCP (REST files kept as .rest)'
+	@echo '  $(GREEN)make mcp-restore$(RESET) Move it back to REST'
+	@echo '  $(GREEN)make mcp-status$(RESET)  Say which transport is live right now'
+	@echo '  $(GREEN)make mcp-server$(RESET)  Run the MCP CRM server on :8931 (second terminal)'
 	@echo ''
 	@echo '$(DIM)  No HubSpot account needed: leave HUBSPOT_BASE_URL pointing at the$(RESET)'
 	@echo '$(DIM)  mock and run "make mock" alongside "make chat".$(RESET)'
@@ -68,3 +77,52 @@ clean: ## Remove models and caches
 	@rm -rf models .rasa
 	@find . -name __pycache__ -type d -prune -exec rm -rf {} + 2>/dev/null || true
 	@echo "$(GREEN)✓ cleaned$(RESET)"
+
+# ==============================================================================
+# The MCP chapter
+# ==============================================================================
+# `mcp-swap` is reversible on purpose. The REST project stays on disk as the
+# baseline the swap is measured against — deleting it would destroy the lesson.
+
+mcp-server: ## Run the MCP CRM server (second terminal, needs make mock too)
+	@$(PYTHON) scripts/mcp_crm_server.py
+
+mcp-prove: check-uv ## Prove the transport swap — no licence, no key, no account
+	@$(UV) run python scripts/prove_mcp_swap.py
+
+mcp-status: ## Report which transport the project is configured for
+	@if grep -q '^mcp_servers:' integrations.yml 2>/dev/null; then \
+		echo "$(GREEN)MCP$(RESET)  — integrations.yml declares mcp_servers:"; \
+		grep -h 'mcp/' skills/*/skill.md | sed 's/^/  /'; \
+	else \
+		echo "$(YELLOW)REST$(RESET) — tools/crm.py and skills/*/tools.py"; \
+	fi
+
+mcp-swap: ## Point the three skills at the MCP server (reversible)
+	@if [ -f integrations.yml.rest ]; then \
+		echo "$(YELLOW)Already swapped — run: make mcp-restore$(RESET)"; exit 1; fi
+	@cp integrations.yml integrations.yml.rest
+	@cp mcp_variant/integrations.yml integrations.yml
+	@for skill in check_tickets identify_customer log_interaction; do \
+		cp skills/$$skill/skill.md skills/$$skill/skill.md.rest; \
+		cp mcp_variant/skills/$$skill/skill.md skills/$$skill/skill.md; \
+	done
+	@for skill in check_tickets log_interaction; do \
+		mv skills/$$skill/tools.py skills/$$skill/tools.py.rest; \
+	done
+	@mv tools/crm.py tools/crm.py.rest
+	@echo "$(GREEN)✓ swapped to MCP.$(RESET)  Start: make mock, make mcp-server, then make train"
+	@echo "$(DIM)  The REST files are still here as .rest — make mcp-restore puts them back.$(RESET)"
+
+mcp-restore: ## Put the REST transport back
+	@if [ ! -f integrations.yml.rest ]; then \
+		echo "$(YELLOW)Not swapped — nothing to restore.$(RESET)"; exit 0; fi
+	@mv integrations.yml.rest integrations.yml
+	@for skill in check_tickets identify_customer log_interaction; do \
+		mv skills/$$skill/skill.md.rest skills/$$skill/skill.md; \
+	done
+	@for skill in check_tickets log_interaction; do \
+		mv skills/$$skill/tools.py.rest skills/$$skill/tools.py; \
+	done
+	@mv tools/crm.py.rest tools/crm.py
+	@echo "$(GREEN)✓ restored to REST.$(RESET)"

--- a/tutorials/rasa-hubspot-crm-tutorial/README.md
+++ b/tutorials/rasa-hubspot-crm-tutorial/README.md
@@ -6,7 +6,7 @@ Assessed on:   2026-09-02
 Assessed by:   Rod Rivera
 Verified with: rasa-pro 3.20.0.dev6, Python 3.11+, uv
 Audience:      Practitioners wiring an agent to a system of record
-Time:          45–60 minutes
+Time:          45–60 minutes, plus 20–30 for the MCP chapter
 ```
 
 A support agent that looks a customer up in HubSpot, reads their open tickets,
@@ -17,6 +17,10 @@ The subject is not HubSpot. It is what changes when a tool stops being a local
 function and starts being a call across a **trust boundary**: credentials,
 timeouts, rate limits, and the difference between "no such customer" and "the
 CRM is down".
+
+Part two then swaps the transport out from under those same three skills — REST
+becomes MCP — and shows that their instructions do not change. See
+[Part two: the same agent over MCP](#part-two-the-same-agent-over-mcp).
 
 ## You do not need a HubSpot account
 
@@ -79,6 +83,12 @@ skills/check_tickets/       LOCAL tool: list_open_tickets
 skills/log_interaction/     LOCAL tool: add_timeline_note
 memory.yml                  PROJECT memory: contact_id, contact_email, contact_name
 scripts/mock_hubspot.py     stand-in CRM so the tutorial runs with no account
+
+mcp_variant/                part two: the same skills, transport swapped
+  integrations.yml          adds the mcp_servers: block
+  skills/*/skill.md         same prose, import_tools: mcp/<server>:<tool>
+scripts/mcp_crm_server.py   an MCP server in front of the same lib/hubspot.py
+scripts/prove_mcp_swap.py   the credential-free proof of the swap
 ```
 
 `find_contact_by_email` is **global** because it passes all three tests from the
@@ -110,6 +120,50 @@ A customer who genuinely is not in the CRM is **not** an error — it returns
 `None`, and the skill asks them to check the address. Confusing "absent" with
 "broken" is the most common mistake in this kind of integration.
 
+## The declared step list
+
+Named for what each step teaches, not for the industry it is dressed in.
+
+| Step | Teaches |
+| --- | --- |
+| `step-01-trust-boundary` | a tool that leaves the process can fail in ways a local one cannot |
+| `step-02-failure-taxonomy` | "absent" and "broken" are different facts, and the agent must say which |
+| `step-03-tool-scope` | which tools are global, which belong to one skill, and the test that decides |
+| `step-04-irreversible-write` | an ordered block plus a runtime confirmation around someone else's system of record |
+| `step-05-transport-swap` | the same instructions over a different transport |
+| `step-06-transport-limits` | what the new transport takes away: memory, stdio, load-time failure |
+| `step-07-channel-shaping` | the narrowest channel decides the shape of the answer |
+
+### Zero overlap with the six-way baseline
+
+[docs/TUTORIAL-TEMPLATE.md](../../docs/TUTORIAL-TEMPLATE.md) records that six
+voice projects in this catalog reduce to one list:
+
+```text
+scaffold | faq | READ-TOOL | tool-constraints | WRITE-TOOL | second-flow | remaining
+```
+
+Strip the industry nouns from both and no step is shared. The baseline teaches
+**how to add a tool**; steps 1–4 here teach **what changes when the tool is
+across a trust boundary**, and steps 5–7 teach **what changes when the
+transport under it is replaced** — a question the baseline cannot ask, because
+it has only ever had one transport.
+
+The two lists do not even have `scaffold` in common: this tutorial has no
+scaffold step, because a reader arrives at part two with a working agent
+already. That is the point of extending a shipped tutorial rather than writing
+a new one — the swap is only visible against something that already worked.
+
+### What this composes
+
+- **Composes:** [`tutorials/rasa-tools-and-memory-tutorial`](../rasa-tools-and-memory-tutorial/README.md)
+- **The question it answers:** where should a tool live, and what may it read?
+- **The question this one answers:** what survives when that tool stops being a
+  local function and becomes a call to someone else's process?
+- **Taken as an input, not taught here:** tool scope, and the memory model. This
+  tutorial assumes you know which tools are global and reuses that judgement
+  unchanged across the swap.
+
 ## Commands
 
 ```bash
@@ -119,12 +173,156 @@ make train      # rasa train
 make chat       # rasa inspect
 make crm-check  # call the CRM directly and print what comes back
 make clean      # remove models and caches
+
+make mcp-prove    # prove the transport swap (no licence, no key, no account)
+make mcp-server   # run the MCP CRM server on :8931
+make mcp-swap     # move the project onto MCP (reversible)
+make mcp-restore  # move it back to REST
+make mcp-status   # say which transport is live
 ```
+
+## Part two: the same agent over MCP
+
+This tutorial used to end with a promise:
+
+> HubSpot also exposes an MCP server, and Mantle has an `mcp_servers:` block in
+> `integrations.yml`. In `3.19.0.dev7` that block is parsed but has no runtime
+> consumer yet — the Mantle engine never connects to it — so this tutorial uses
+> REST. When MCP lands, the same three skills can keep their instructions and
+> swap `tools/crm.py` for imported remote tools.
+
+MCP has landed, and the promise held. `rasa-pro 3.20.0.dev6` connects to
+`mcp_servers:` and resolves `import_tools: mcp/<server>:<tool>` at model load.
+The three skills now run against a remote MCP server **with their instructions
+unchanged**.
+
+Not "barely changed". Unchanged. Here is the entire difference, all three skills:
+
+```diff
+--- skills/identify_customer/skill.md
++++ mcp_variant/skills/identify_customer/skill.md
+ import_tools:
+-  - find_contact_by_email
++  - mcp/hubspot_crm:find_contact_by_email
+
+--- skills/check_tickets/skill.md
++++ mcp_variant/skills/check_tickets/skill.md
++import_tools:
++  - mcp/hubspot_crm:list_open_tickets
+
+--- skills/log_interaction/skill.md
++++ mcp_variant/skills/log_interaction/skill.md
++import_tools:
++  - mcp/hubspot_crm:add_timeline_note
+```
+
+Every changed line is inside the YAML frontmatter. Not one line of instruction
+prose moved — the branching on `not_identified`, the `waiting_on_us` wording,
+the ordered block, the confirmation constraint, all byte-identical. `make
+mcp-prove` asserts that, and fails if it ever stops being true.
+
+The lesson is the one thing a from-scratch MCP tutorial cannot teach: **skill
+instructions are written against a tool's name and result shape, not against its
+transport.** Change the wire and the prose survives, because the prose was never
+about the wire.
+
+Published chapters: **[Instructions Survive the
+Transport](https://rasa.community/library/tutorials/crm-transport-swap/)**.
+
+### Try it
+
+```bash
+make mcp-prove     # no licence, no API key, no HubSpot account
+```
+
+Then run the agent on MCP:
+
+```bash
+make mock          # terminal 1: the mock CRM
+make mcp-server    # terminal 2: the MCP server in front of it
+make mcp-swap      # move the project onto MCP
+make train && make chat
+make mcp-restore   # put REST back
+```
+
+`make mcp-swap` is reversible on purpose: the REST project is the baseline the
+swap is measured against, so it stays on disk rather than being replaced.
+
+### What MCP does not do for you
+
+The swap is small, and the temptation is to conclude MCP is free. Three limits,
+each of which the engine enforces rather than merely recommends.
+
+**1. An MCP tool has no memory.** A local `@tool` receives a `ToolContext` and
+can read and write project memory. An MCP tool does not — the engine says so
+itself, in `skill_executor.py`:
+
+> Local tools receive a `ToolContext`; MCP tools dispatch through the
+> processor-owned `MCPRuntime`.
+
+So `list_open_tickets`, which read `project.contact_id` out of memory in the
+REST version, takes a `contact_id` **parameter** in the MCP version, and the
+model fills it from the conversation. The instructions did not change; the
+plumbing under them did. If a tool's correctness depends on a value the user
+must not be able to influence, that value cannot be an MCP argument — keep that
+tool local.
+
+**2. There is no stdio transport.** `MCPServerSpec` requires a `url:` whose
+scheme is `http` or `https`, and `MCPServerConnection` only ever builds a
+`streamablehttp_client`. A stdio MCP server — the form most desktop MCP clients
+speak — cannot be reached by this engine at all. The bundled server is therefore
+an HTTP server on loopback.
+
+**3. A missing remote tool is a load-time failure, not a train-time one.**
+`parse_mcp_imports` checks the *syntax* of every `mcp/<server>:<tool>` reference
+and catches collisions, but it cannot check that the server actually offers the
+tool: that needs a live `list_tools`. So `rasa train` passes and the failure
+lands at model load, from `MCPRuntime.prepare`:
+
+```text
+MCP server 'hubspot_crm' does not expose imported tool 'list_tickets'
+```
+
+A typo in an import line is caught late. `make mcp-prove` is what moves that
+check back to before you train.
+
+And the guarantees you already had do survive. The `requires_confirmation`
+constraint on `add_timeline_note` still fires — `tool_constraints_executor.py`
+resolves MCP tools through the same `has_mcp_tool` lookup, so the runtime still
+asks before a remote write lands. A constraint is a property of the skill, not
+of the transport.
+
+### Channel formatting: the same answer, shaped for where it lands
+
+`integrations.yml` declares two channels, `rest` and `inspector`, and the agent
+answers on both. The tool result is identical; what differs is what the reader
+can see.
+
+The ticket list is the case that shows it. `list_open_tickets` returns
+structured rows — id, subject, stage, created — and the Inspector renders that
+happily as several lines. The same several lines pushed through the REST channel
+arrive as one blob of text, and read by a voice channel they would be unusable.
+
+That is why the `check_tickets` instructions say
+
+> read back each subject and its stage in plain language
+
+rather than "return the ticket list". The skill is told to produce a spoken
+sentence, not a table, because the narrowest channel the agent serves decides
+the shape of the answer. Formatting is a skill-level decision made once, not a
+per-channel template — which is also why it did not have to change when the
+transport did.
 
 ## What comes next
 
-HubSpot also exposes an MCP server, and Mantle has an `mcp_servers:` block in
-`integrations.yml`. In `3.19.0.dev7` that block is parsed but has no runtime
-consumer yet — the Mantle engine never connects to it — so this tutorial uses
-REST. When MCP lands, the same three skills can keep their instructions and swap
-`tools/crm.py` for imported remote tools.
+Point `mcp_servers:` at HubSpot's own MCP server instead of the bundled one:
+
+```yaml
+mcp_servers:
+  - name: hubspot_crm
+    url: https://mcp.hubspot.com/anthropic
+    token: ${HUBSPOT_ACCESS_TOKEN}
+```
+
+Two lines, and the same three skills. That is the claim this chapter exists to
+make checkable.

--- a/tutorials/rasa-hubspot-crm-tutorial/mcp_variant/integrations.yml
+++ b/tutorials/rasa-hubspot-crm-tutorial/mcp_variant/integrations.yml
@@ -1,0 +1,47 @@
+# The MCP variant of integrations.yml.
+#
+# Identical to the project's integrations.yml except for the `mcp_servers:`
+# block at the bottom. `make mcp-swap` copies this over the REST one; `make
+# mcp-restore` puts the REST one back.
+#
+# Text-first: the subject is the CRM boundary, not speech.
+# The orchestrator LLM is a model-group reference. Provider, model and
+# credentials live on the named group, never inline under `llm:` — the
+# inline form was removed in rasa-pro 3.20.0.dev6.
+llm:
+  model_group: orchestrator
+
+model_groups:
+  - id: orchestrator
+    models:
+      - provider: openai
+        model: gpt-4.1-mini
+        api_key: ${OPENAI_API_KEY}
+        temperature: 0.0
+
+channels:
+  rest:
+    enabled: true
+  inspector:
+    enabled: true
+
+# ------------------------------------------------------------------------------
+# The transport swap lives here.
+# ------------------------------------------------------------------------------
+# `name:` is the server id the skills name in `import_tools: mcp/<name>:<tool>`.
+# It must match byte for byte — a typo is caught at model load by MCPRuntime,
+# not at train time, because remote tool existence needs a live `list_tools`.
+#
+# `url:` must be http or https. Mantle has no stdio transport: MCPServerSpec
+# rejects any other scheme and MCPServerConnection only ever builds a
+# streamablehttp_client. As shipped this points at the bundled MCP server on
+# loopback, so no account and no network are needed.
+#
+# Against HubSpot's own MCP server this becomes their URL plus a token:
+#     url: https://mcp.hubspot.com/anthropic
+#     token: ${HUBSPOT_ACCESS_TOKEN}
+# The skills do not change for that either — only these two lines.
+mcp_servers:
+  - name: hubspot_crm
+    url: http://127.0.0.1:8931/mcp
+    tool_timeout: 15

--- a/tutorials/rasa-hubspot-crm-tutorial/mcp_variant/skills/check_tickets/skill.md
+++ b/tutorials/rasa-hubspot-crm-tutorial/mcp_variant/skills/check_tickets/skill.md
@@ -1,0 +1,22 @@
+---
+name: Check Tickets
+description: >
+  Tell the caller what support tickets are on their account. Activate for open
+  tickets, case status, or what is happening with my issue.
+import_tools:
+  - mcp/hubspot_crm:list_open_tickets
+---
+
+Report the caller's tickets.
+
+Call `list_open_tickets`. It reads the identified customer from project memory,
+so it is the authority on whether the caller has been identified yet.
+
+- `not_identified`: say you need their email address first and let the Identify
+  Customer skill run. Do not list anything.
+- Success with `count` of zero: tell them there is nothing open.
+- Success with tickets: read back each subject and its stage in plain language.
+  `waiting_on_us` means Meridian owes them a reply; `waiting_on_contact` means
+  the ticket is waiting on the customer.
+- Any other error: say you could not reach the CRM. Never describe a ticket that
+  did not come back from the tool.

--- a/tutorials/rasa-hubspot-crm-tutorial/mcp_variant/skills/identify_customer/skill.md
+++ b/tutorials/rasa-hubspot-crm-tutorial/mcp_variant/skills/identify_customer/skill.md
@@ -1,0 +1,26 @@
+---
+name: Identify Customer
+description: >
+  Find the caller in the CRM from their email address. Activate when they give
+  an email, introduce themselves, or when another skill needs an identified
+  customer and there is not one yet.
+import_tools:
+  - mcp/hubspot_crm:find_contact_by_email
+---
+
+Identify the caller.
+
+If they have already given an email address in what they just said, call
+`find_contact_by_email` with it straight away. Do not ask them to repeat it.
+Otherwise ask for the email address on their account, once, then call the tool.
+
+Read the result before replying:
+
+- Success: greet them by the returned name, mention their company, and ask what
+  they need. Do not read the contact id aloud.
+- `contact_not_found`: the CRM answered and nobody matches. Say you cannot find
+  that address and ask them to check it or try another one.
+- `crm_auth_failed`, `crm_timeout`, `crm_unreachable`, `crm_rate_limited`,
+  `crm_not_configured`: you could not reach the CRM. Say so plainly and offer to
+  take a message. Never guess who they are, and never continue as if they were
+  identified.

--- a/tutorials/rasa-hubspot-crm-tutorial/mcp_variant/skills/log_interaction/skill.md
+++ b/tutorials/rasa-hubspot-crm-tutorial/mcp_variant/skills/log_interaction/skill.md
@@ -1,0 +1,47 @@
+---
+name: Log Interaction
+description: >
+  Write a short summary of this conversation to the customer's CRM timeline.
+  Activate for log this, make a note, or record what we discussed.
+import_tools:
+  - mcp/hubspot_crm:add_timeline_note
+tool_constraints:
+  - add_timeline_note:
+      requires_confirmation:
+        enabled: true
+        utter_for_confirmation: utter_confirm_note
+        utter_on_user_denial: utter_note_cancelled
+---
+
+Record what the caller wanted, on their CRM record.
+
+Two guarantees sit between the caller and someone else's system of record, and
+neither is prose the model can talk itself out of.
+
+The **ordered block** fixes the sequence: draft, then write, in that order. The
+**confirmation constraint** in the frontmatter makes the runtime itself ask
+before the write lands, and cancel if the caller says no.
+
+:::ordered_block id=save_note
+steps:
+  - id: draft_summary
+    instructions: |
+      Write one or two sentences in the third person summarising what the
+      caller wanted, and set note_summary to it. Do not ask for permission
+      here — the runtime asks before anything is saved.
+    complete_when: session.log_interaction.note_summary
+  - id: write_note
+    execute_tool: add_timeline_note
+    parameters:
+      summary: session.log_interaction.note_summary
+:::
+
+## After the write
+
+Read the tool result before you reply.
+
+- Success: confirm briefly that it is on their record.
+- `not_identified`: say you need their email address first and let the Identify
+  Customer skill run.
+- Any other error: say plainly that the note was **not** saved, and offer to try
+  again. Never report a save that the tool did not confirm.

--- a/tutorials/rasa-hubspot-crm-tutorial/scripts/mcp_crm_server.py
+++ b/tutorials/rasa-hubspot-crm-tutorial/scripts/mcp_crm_server.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""A local MCP server exposing the same three CRM tools over MCP.
+
+This is the remote end of the transport swap. It publishes `find_contact_by_email`,
+`list_open_tickets`, and `add_timeline_note` as MCP tools with the same names and
+the same argument shapes the local `@tool` functions had, so the skills that
+import them do not have to be rewritten.
+
+    python scripts/mcp_crm_server.py            # serves on 127.0.0.1:8931/mcp
+
+It talks to the CRM through `lib/hubspot.py` — the same client the REST version
+uses, unchanged. Pointed at `scripts/mock_hubspot.py` it needs no HubSpot account
+and no network beyond loopback.
+
+WHY HTTP AND NOT STDIO
+----------------------
+Mantle connects to MCP servers over streamable HTTP only. `MCPServerSpec` in
+`rasa/mantle/config/integrations.py` requires a `url:` whose scheme is `http` or
+`https` and rejects anything else, and `MCPServerConnection._run_lifecycle` in
+`rasa/shared/utils/mcp/server_connection.py` builds a `streamablehttp_client`
+with no stdio branch. A stdio server cannot be reached by this engine at all.
+Loopback HTTP is the credential-free equivalent: no account, no billing, and no
+packet leaves the machine.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, _ROOT)
+
+from dotenv import load_dotenv  # noqa: E402
+
+load_dotenv(os.path.join(_ROOT, ".env"))
+
+from mcp.server.fastmcp import FastMCP  # noqa: E402
+from pydantic import BaseModel  # noqa: E402
+
+from lib.hubspot import (  # noqa: E402
+    CrmError,
+    find_contact_by_email as _find,
+    log_note,
+    open_tickets_for,
+)
+
+HOST, PORT = "127.0.0.1", 8931
+
+mcp = FastMCP("hubspot-crm", host=HOST, port=PORT, stateless_http=True)
+
+
+# WHY THESE RETURN MODELS EXIST — a real finding, caught by scripts/prove_mcp_swap.py.
+#
+# A tool annotated `-> dict` publishes NO outputSchema, so FastMCP sends the
+# result as unstructured text and `CallToolResult.structuredContent` is None.
+# Mantle notices: `MCPRuntime._invoke_mcp_tool` uses structuredContent when it
+# is present and otherwise falls back to dumping the content blocks, so the
+# model would receive a JSON string wrapped in a list of text parts instead of
+# the flat object the local `@tool` returned.
+#
+# The skill instructions branch on `ok` and `error`. Those names have to
+# survive the wire for the prose to keep working — which is the whole claim.
+# An explicit return model is what makes them survive: it publishes an
+# outputSchema, so structuredContent comes back populated and the payload the
+# model sees is the same shape the REST tool produced.
+#
+# `extra="allow"` keeps the error variants ( {"ok": false, "error": ...} )
+# expressible through the same model.
+class CrmResult(BaseModel):
+    """Flat result object, mirroring what the local @tool returned."""
+
+    model_config = {"extra": "allow"}
+
+    ok: bool
+
+
+@mcp.tool(
+    description=(
+        "Find the customer in the CRM by their email address. "
+        "Call this before discussing anything about their account."
+    )
+)
+async def find_contact_by_email(email: str) -> CrmResult:
+    """Look the caller up in HubSpot.
+
+    Args:
+        email: The customer's email address.
+    """
+    try:
+        contact = await _find(email)
+    except CrmError as exc:
+        return CrmResult(ok=False, error=exc.reason)
+
+    if contact is None:
+        # Not an error: the CRM answered, and nobody matches.
+        return CrmResult(ok=False, error="contact_not_found", email=email)
+
+    return CrmResult(
+        ok=True,
+        contact_id=contact.id,
+        name=contact.full_name,
+        company=contact.company,
+    )
+
+
+@mcp.tool(description="List the support tickets on the identified customer's account.")
+async def list_open_tickets(contact_id: str) -> CrmResult:
+    """Read the caller's tickets from the CRM.
+
+    Args:
+        contact_id: HubSpot contact id of the identified customer.
+    """
+    # `contact_id` is a PARAMETER here, not a memory read. An MCP tool has no
+    # ToolContext, so the value has to travel as an argument. See the README
+    # section "What MCP does not do for you".
+    if not contact_id:
+        return CrmResult(ok=False, error="not_identified")
+    try:
+        tickets = await open_tickets_for(str(contact_id))
+    except CrmError as exc:
+        return CrmResult(ok=False, error=exc.reason)
+    return CrmResult(ok=True, count=len(tickets), tickets=tickets)
+
+
+@mcp.tool(
+    description="Save a short summary of this conversation to the customer's CRM timeline."
+)
+async def add_timeline_note(contact_id: str, summary: str) -> CrmResult:
+    """Write a note onto the customer's CRM record.
+
+    Args:
+        contact_id: HubSpot contact id of the identified customer.
+        summary: One or two sentences describing what the caller wanted.
+    """
+    if not contact_id:
+        return CrmResult(ok=False, error="not_identified")
+    try:
+        note_id = await log_note(str(contact_id), summary)
+    except CrmError as exc:
+        # A failed write is the dangerous one: never let the agent claim it
+        # saved something that is not there.
+        return CrmResult(ok=False, error=exc.reason)
+    return CrmResult(ok=True, note_id=note_id)
+
+
+if __name__ == "__main__":
+    print(f"MCP CRM server listening on http://{HOST}:{PORT}/mcp", flush=True)
+    print("  tools: find_contact_by_email, list_open_tickets, add_timeline_note", flush=True)
+    print("  stop with Ctrl-C", flush=True)
+    mcp.run(transport="streamable-http")

--- a/tutorials/rasa-hubspot-crm-tutorial/scripts/prove_mcp_swap.py
+++ b/tutorials/rasa-hubspot-crm-tutorial/scripts/prove_mcp_swap.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+"""Prove the transport swap: same instructions, different transport.
+
+    make mcp-prove
+
+No licence, no API key, no HubSpot account, no network beyond loopback. It
+starts both mock servers itself, so there is nothing to run in another terminal.
+
+Six checks, and each one fails loudly rather than warning:
+
+  1. SKILL PROSE IS BYTE-IDENTICAL. The REST skill.md and the MCP skill.md
+     differ only inside the YAML frontmatter. Every changed line is an
+     `import_tools:` line. If a single line of instruction prose differs, this
+     fails — that is the claim the whole tutorial rests on.
+  2. `parse_mcp_servers` accepts the MCP integrations.yml and yields the server
+     id the skills import.
+  3. `try_parse_mcp_tool_import` parses each `mcp/<server>:<tool>` reference,
+     and `get_bare_tool_name` returns the name the LLM will see.
+  4. Every imported server id is actually configured. This is the check that
+     turns a typo into an error instead of a silent missing tool.
+  5. The MCP server really exposes the three imported tool names — over a real
+     MCP session, the same `list_tools` call `MCPRuntime.prepare` makes.
+  6. Calling `find_contact_by_email` over MCP returns the same customer the
+     REST tool returns. Same fact, different wire.
+
+Written to fail first. Break the swap — rename the server under `mcp_servers:`,
+or a tool name in an `import_tools:` line, or edit a line of skill prose — and
+the matching check goes red.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import os
+import socket
+import subprocess
+import sys
+import time
+
+_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, _ROOT)
+
+GREEN, RED, DIM, RESET = (
+    ("\033[92m", "\033[91m", "\033[2m", "\033[0m")
+    if sys.stdout.isatty()
+    else ("", "", "", "")
+)
+
+MCP_HOST, MCP_PORT = "127.0.0.1", 8931
+CRM_HOST, CRM_PORT = "127.0.0.1", 8787
+MCP_URL = f"http://{MCP_HOST}:{MCP_PORT}/mcp"
+
+SKILLS = {
+    "identify_customer": "find_contact_by_email",
+    "check_tickets": "list_open_tickets",
+    "log_interaction": "add_timeline_note",
+}
+SERVER_ID = "hubspot_crm"
+
+_failures: list[str] = []
+
+
+def check(label: str, ok: bool, detail: str = "") -> bool:
+    mark = f"{GREEN}✓{RESET}" if ok else f"{RED}✗{RESET}"
+    print(f"  {mark} {label:<44} {detail}")
+    if not ok:
+        _failures.append(label)
+    return ok
+
+
+def _read(path: str) -> str:
+    with open(os.path.join(_ROOT, path), encoding="utf-8") as handle:
+        return handle.read()
+
+
+# ---------------------------------------------------------------------------
+# 1. The claim: instructions survive the transport.
+# ---------------------------------------------------------------------------
+def prove_prose_unchanged() -> None:
+    """Every difference between the REST and MCP skills is an import line."""
+    print(f"\n{DIM}  1. skill instructions are unchanged by the swap{RESET}")
+    import difflib
+
+    for skill in sorted(SKILLS):
+        rest = _read(f"skills/{skill}/skill.md").splitlines()
+        mcp = _read(f"mcp_variant/skills/{skill}/skill.md").splitlines()
+
+        changed = [
+            line[1:].strip()
+            for line in difflib.unified_diff(rest, mcp, n=0, lineterm="")
+            if line.startswith(("+", "-")) and not line.startswith(("+++", "---"))
+        ]
+        # Every changed line must be an import declaration: either the
+        # `import_tools:` key itself or one of its list entries.
+        offending = [
+            line
+            for line in changed
+            if line != "import_tools:" and not line.startswith("- ")
+        ]
+        check(
+            f"{skill}: only import_tools differs",
+            not offending,
+            f"{DIM}{len(changed)} changed line(s){RESET}"
+            if not offending
+            else f"{RED}prose changed: {offending}{RESET}",
+        )
+
+        # And the body below the frontmatter must be identical, byte for byte.
+        rest_body = _read(f"skills/{skill}/skill.md").split("---\n", 2)[-1]
+        mcp_body = _read(f"mcp_variant/skills/{skill}/skill.md").split("---\n", 2)[-1]
+        check(
+            f"{skill}: instruction body byte-identical",
+            rest_body == mcp_body,
+            f"{DIM}{len(rest_body)} bytes{RESET}"
+            if rest_body == mcp_body
+            else f"{RED}bodies differ{RESET}",
+        )
+
+
+# ---------------------------------------------------------------------------
+# 2-4. Static configuration: what the engine checks at model load.
+# ---------------------------------------------------------------------------
+def prove_static_config() -> set[str]:
+    """Parse integrations.yml and the import references the way Mantle does."""
+    from rasa.mantle.config.mcp import parse_mcp_servers
+    from rasa.mantle.tools.mcp_import_spec import (
+        get_bare_tool_name,
+        try_parse_mcp_tool_import,
+    )
+    from rasa.shared.utils.yaml import read_yaml_file
+
+    print(f"\n{DIM}  2. integrations.yml parses as MCP server configuration{RESET}")
+    raw = read_yaml_file(
+        os.path.join(_ROOT, "mcp_variant/integrations.yml"), expand_env_vars=False
+    )
+    settings = parse_mcp_servers(raw.get("mcp_servers") or [])
+    configured = set(settings.servers)
+    check(
+        "parse_mcp_servers accepts the file",
+        configured == {SERVER_ID},
+        f"{DIM}servers: {sorted(configured)}{RESET}",
+    )
+    # Look the server up defensively: when the id has been renamed, check 2
+    # has already gone red and the remaining checks should still report rather
+    # than disappear behind a traceback.
+    configured_server = settings.servers.get(SERVER_ID)
+    check(
+        "server url is loopback http",
+        configured_server is not None and configured_server.url == MCP_URL,
+        f"{DIM}{configured_server.url}{RESET}"
+        if configured_server is not None
+        else f"{RED}no server named {SERVER_ID!r}{RESET}",
+    )
+
+    print(f"\n{DIM}  3. each skill's import parses as mcp/<server>:<tool>{RESET}")
+    imported: set[str] = set()
+    for skill, tool in sorted(SKILLS.items()):
+        text = _read(f"mcp_variant/skills/{skill}/skill.md")
+        reference = f"mcp/{SERVER_ID}:{tool}"
+        declared = reference in text
+        parsed = try_parse_mcp_tool_import(reference)
+        bare = get_bare_tool_name(reference)
+        imported.add(parsed.server_id)
+        check(
+            f"{skill} imports {tool}",
+            declared and parsed.tool_name == tool and bare == tool,
+            f"{DIM}server={parsed.server_id} llm sees '{bare}'{RESET}"
+            if declared
+            else f"{RED}reference not found in skill.md{RESET}",
+        )
+
+    print(f"\n{DIM}  4. every imported server is configured{RESET}")
+    missing = imported - configured
+    check(
+        "no skill imports an unconfigured server",
+        not missing,
+        f"{DIM}{sorted(imported)} ⊆ {sorted(configured)}{RESET}"
+        if not missing
+        else f"{RED}missing from integrations.yml: {sorted(missing)}{RESET}",
+    )
+    return configured
+
+
+# ---------------------------------------------------------------------------
+# 5-6. The live half: a real MCP session against the bundled server.
+# ---------------------------------------------------------------------------
+async def prove_live_mcp() -> None:
+    """List and call tools over MCP, exactly as MCPRuntime.prepare does."""
+    from mcp import ClientSession
+    from mcp.client.streamable_http import streamablehttp_client
+
+    print(f"\n{DIM}  5. the MCP server exposes the imported tools{RESET}")
+    async with streamablehttp_client(MCP_URL) as (read_stream, write_stream, _):
+        async with ClientSession(read_stream, write_stream) as session:
+            await session.initialize()
+
+            listed = await session.list_tools()
+            remote = {tool.name for tool in listed.tools}
+            for skill, tool in sorted(SKILLS.items()):
+                check(
+                    f"server exposes {tool}",
+                    tool in remote,
+                    f"{DIM}imported by {skill}{RESET}"
+                    if tool in remote
+                    else f"{RED}not offered by the server{RESET}",
+                )
+
+            print(f"\n{DIM}  6. a tool call over MCP returns the CRM fact{RESET}")
+            result = await session.call_tool(
+                "find_contact_by_email", {"email": "dana.okafor@example.com"}
+            )
+            # structuredContent must be populated, not None. Mantle only gets a
+            # flat object when the tool publishes an outputSchema; without one
+            # it falls back to dumping content blocks and the skill prose that
+            # branches on `ok` / `error` stops matching what the model sees.
+            # This assertion is here because the first version of the server
+            # returned bare dicts and failed exactly this way.
+            check(
+                "result is structured, not text blocks",
+                result.structuredContent is not None,
+                f"{DIM}outputSchema published{RESET}"
+                if result.structuredContent is not None
+                else f"{RED}structuredContent is None — tool has no outputSchema{RESET}",
+            )
+            payload = result.structuredContent or {}
+            check(
+                "find_contact_by_email over MCP",
+                payload.get("ok") is True and payload.get("name") == "Dana Okafor",
+                f"{DIM}{payload.get('name')} at {payload.get('company')}{RESET}",
+            )
+
+            # The absent/broken distinction the REST tutorial teaches survives
+            # too: a CRM that answers "nobody matches" is not a CRM that is down.
+            absent = await session.call_tool(
+                "find_contact_by_email", {"email": "nobody@example.com"}
+            )
+            absent_payload = absent.structuredContent or {}
+            check(
+                "absent contact is not an error",
+                absent_payload.get("error") == "contact_not_found",
+                f"{DIM}error={absent_payload.get('error')}{RESET}",
+            )
+
+
+# ---------------------------------------------------------------------------
+# Server plumbing: start both mocks, wait for the ports, tear them down.
+# ---------------------------------------------------------------------------
+def _wait_for_port(host: str, port: int, timeout: float = 25.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        with contextlib.suppress(OSError):
+            with socket.create_connection((host, port), timeout=0.5):
+                return True
+        time.sleep(0.15)
+    return False
+
+
+@contextlib.contextmanager
+def _servers():
+    """Run the mock CRM and the MCP server for the duration of the proof."""
+    env = dict(os.environ)
+    env.setdefault("HUBSPOT_BASE_URL", f"http://{CRM_HOST}:{CRM_PORT}")
+    env.setdefault("HUBSPOT_ACCESS_TOKEN", "mock-token")
+    procs = []
+    try:
+        for script, host, port in (
+            ("scripts/mock_hubspot.py", CRM_HOST, CRM_PORT),
+            ("scripts/mcp_crm_server.py", MCP_HOST, MCP_PORT),
+        ):
+            procs.append(
+                subprocess.Popen(
+                    [sys.executable, os.path.join(_ROOT, script)],
+                    env=env,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                )
+            )
+            if not _wait_for_port(host, port):
+                raise SystemExit(f"{RED}  {script} did not come up on {port}{RESET}")
+        yield
+    finally:
+        for proc in procs:
+            proc.terminate()
+            with contextlib.suppress(subprocess.TimeoutExpired):
+                proc.wait(timeout=5)
+
+
+def main() -> int:
+    print()
+    print("  Proving: the same three skills keep their instructions while")
+    print("  tools/crm.py is replaced by import_tools: mcp/<server>:<tool>.")
+    print(f"{DIM}  No licence, no API key, no HubSpot account, loopback only.{RESET}")
+
+    prove_prose_unchanged()
+    prove_static_config()
+    with _servers():
+        asyncio.run(prove_live_mcp())
+
+    print()
+    if _failures:
+        print(f"{RED}  {len(_failures)} check(s) failed:{RESET}")
+        for label in _failures:
+            print(f"{RED}    - {label}{RESET}")
+        print()
+        return 1
+    print(f"{GREEN}  The transport changed. The instructions did not.{RESET}")
+    print()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Chartered by **RULING-012 §s3**. Keeps a promise this catalog made **in print**:

> `tutorials/rasa-hubspot-crm-tutorial/README.md:125-129` — *"When MCP lands, the same three
> skills can keep their instructions and swap `tools/crm.py` for imported remote tools."*

**MCP has landed.** So the promise is now checkable, and this PR checks it.

## The diff is the artifact

Every changed line across all three skills is inside YAML frontmatter. **Six lines total:**

```diff
 import_tools:
-  - find_contact_by_email
+  - mcp/hubspot_crm:find_contact_by_email
+  - mcp/hubspot_crm:list_open_tickets
+  - mcp/hubspot_crm:add_timeline_note
```

Asserted **mechanically, not by eye**: the proof splits each skill on the second `---` and
compares bodies byte for byte — `687 / 804 / 1226 bytes`, all identical. The ordered block,
`requires_confirmation`, both utterances, every `memory.yml`, `lib/hubspot.py` and `agent.yml`
are untouched.

## The finding that matters most

**No skill instruction changed — but the proof caught a bug that would have falsified the claim
silently, and it is not in the skills.**

Tools annotated `-> dict` publish no `outputSchema`, so FastMCP returns unstructured text and
`structuredContent` is `None`. `MCPRuntime._invoke_mcp_tool` (`mcp_runtime.py:203-207`) then
dumps content blocks instead. The skills branch on `ok`/`error` — the model would have received
a JSON string wrapped in text parts. **Files unchanged, behaviour broken.** Fixed with an
explicit `CrmResult` return model; an assertion now pins it.

> *"Instructions unchanged" is a claim about what the model receives, not only about what the
> files say — and those can come apart.*

That sentence is worth more than the tutorial.

The one thing genuinely rebuilt was **not** prose: `list_open_tickets` read `project.contact_id`
from `ToolContext`, which an MCP tool has none of, so it takes a `contact_id` parameter.
Interface preserved, implementation replaced.

## Credential-free proof, verified by mutation during review

`make mcp-prove` — 18 assertions, no licence, no key, no account, loopback only; starts and
tears down its mock servers itself. Broken three ways by the stream, each red with exit 1
(server renamed, tool renamed, one line of skill prose edited).

Reproduced independently: I edited a single line of skill prose → **exit 1, proof red**;
restored → green, tree clean. The "instructions unchanged" claim is **mechanically enforced**,
not asserted.

## Declared step list — zero overlap

```
trust-boundary · failure-taxonomy · tool-scope · irreversible-write
transport-swap · transport-limits · channel-shaping
```

Against the six-way baseline (`scaffold | faq | READ-TOOL | tool-constraints | WRITE-TOOL |
second-flow | remaining`): **no step shared** — not even `scaffold`, because the reader arrives
with a working agent. The baseline teaches *how to add a tool*; this teaches *what changes
across a trust boundary*, then *what changes when the transport is replaced* — a question that
needs two transports, which the baseline has never had.

## Gates

```
✓ All 18 checks passed.
✓ validate passed — repository is internally consistent.
validate_project clean on BOTH the REST baseline and the swapped MCP project.
```

## Two errors in my charter, both confirmed and corrected in the corpus

1. **"stdio mock server" is not implementable — and I wrote it into a `done_when`**, making my
   own SOW unsatisfiable. Mantle is streamable-HTTP only: `integrations.py:132-142` raises
   *"MCP server URL must use http or https"*, and no stdio branch exists anywhere. The stream
   substituted a loopback HTTP server — same intent (no account, no billing, nothing leaves the
   machine) — and turned the limitation into chapter content. Correct call.
2. **`validator.py:1654-1669` was the wrong citation** — that is
   `verify_mcp_meta_map_slots_against_domain`, a **CALM** validator reading `endpoints.yml`.
   Mantle's path is `load_integration_mcp_servers` → `parse_mcp_servers` over
   `integrations.yml`. I cited the wrong engine to support a Mantle claim.

**The central claim survives and is stronger than I stated it:**
`tool_constraints_executor.py:309-325` resolves MCP tools through `has_mcp_tool`, so
`requires_confirmation` **survives the swap** — the sharpest available evidence that a guarantee
is a property of the skill, not of the transport.
