### PR TITLE
fictional-data: every name is invented, and the 19th lint check holds it

### DIFF
--- a/community/samrudh-gemini-voice-agent/data/source/README.md
+++ b/community/samrudh-gemini-voice-agent/data/source/README.md
@@ -1,0 +1,7 @@
+# Fixture data — entirely fictional
+
+Every person, company, account, and event in this directory is **invented for
+this project**. Nothing corresponds to a real person, a real business, or any
+real conversation. Do not replace these records with real customer data — the
+repo-wide `fictional-data` lint rejects real institutions and unreserved email
+domains, and this catalog is public.

--- a/community/samrudh-gemini-voice-agent/skills/trip_faq/references/README.md
+++ b/community/samrudh-gemini-voice-agent/skills/trip_faq/references/README.md
@@ -1,0 +1,7 @@
+# Fixture data — entirely fictional
+
+Every person, company, account, and event in this directory is **invented for
+this project**. Nothing corresponds to a real person, a real business, or any
+real conversation. Do not replace these records with real customer data — the
+repo-wide `fictional-data` lint rejects real institutions and unreserved email
+domains, and this catalog is public.

--- a/docs/TUTORIAL-TEMPLATE.md
+++ b/docs/TUTORIAL-TEMPLATE.md
@@ -352,8 +352,16 @@ These are not new. They are enforced by `scripts/lint_repo.py` and
 `make validate`, and they are listed here so a tutorial author does not have to
 discover them by failing CI.
 
-- **Fixture data only.** Seeded demo identities under `data/source/`. No real
-  customer data, ever, including in transcripts pasted into chapters.
+- **Fixture data only — and fictional NAMES for everything.** Seeded demo
+  identities under `data/source/`. No real customer data, ever, including in
+  transcripts pasted into chapters — and no real people, companies or
+  institutions either, however inspired the use case is by a real
+  conversation: one real name presented as data reads as a confidential
+  disclosure whatever the intent. Invent the business. Emails use
+  `example.com/org/net`. Every `data/source/` and `references/` directory
+  carries a README declaring its contents fictional. Enforced by the
+  `fictional-data` check in `scripts/lint_repo.py`, which also rejects a
+  maintained list of real institutions by name.
 - **`.env.example` completeness.** Every key the project reads is named there,
   and every key declared in `[tool.rasa-catalog] required-secrets` appears in
   it. Enforced by `check_env_examples`.
@@ -443,6 +451,8 @@ Runnable half:
 - [ ] `README.md` carries the RESOURCE_TEMPLATE metadata block
 - [ ] `tutorials/README.md` has a row for the new directory
 - [ ] `.env.example` names every key
+- [ ] every identity is fictional; fixture dirs carry their fictional-data
+      README (`fictional-data` lint passes)
 - [ ] no DU suite; any e2e file opens with the observation-not-proof header
 
 Prose half:

--- a/examples/mantle-voice-agent/data/source/README.md
+++ b/examples/mantle-voice-agent/data/source/README.md
@@ -1,0 +1,7 @@
+# Fixture data — entirely fictional
+
+Every person, company, account, and event in this directory is **invented for
+this project**. Nothing corresponds to a real person, a real business, or any
+real conversation. Do not replace these records with real customer data — the
+repo-wide `fictional-data` lint rejects real institutions and unreserved email
+domains, and this catalog is public.

--- a/examples/mantle-voice-agent/skills/trip_faq/references/README.md
+++ b/examples/mantle-voice-agent/skills/trip_faq/references/README.md
@@ -1,0 +1,7 @@
+# Fixture data — entirely fictional
+
+Every person, company, account, and event in this directory is **invented for
+this project**. Nothing corresponds to a real person, a real business, or any
+real conversation. Do not replace these records with real customer data — the
+repo-wide `fictional-data` lint rejects real institutions and unreserved email
+domains, and this catalog is public.

--- a/examples/mantle-voice-appointment-skills/data/source/README.md
+++ b/examples/mantle-voice-appointment-skills/data/source/README.md
@@ -1,0 +1,7 @@
+# Fixture data — entirely fictional
+
+Every person, company, account, and event in this directory is **invented for
+this project**. Nothing corresponds to a real person, a real business, or any
+real conversation. Do not replace these records with real customer data — the
+repo-wide `fictional-data` lint rejects real institutions and unreserved email
+domains, and this catalog is public.

--- a/examples/mantle-voice-appointment-skills/skills/clinic_faq/references/README.md
+++ b/examples/mantle-voice-appointment-skills/skills/clinic_faq/references/README.md
@@ -1,0 +1,7 @@
+# Fixture data — entirely fictional
+
+Every person, company, account, and event in this directory is **invented for
+this project**. Nothing corresponds to a real person, a real business, or any
+real conversation. Do not replace these records with real customer data — the
+repo-wide `fictional-data` lint rejects real institutions and unreserved email
+domains, and this catalog is public.

--- a/examples/mantle-voice-banking-skills/data/source/README.md
+++ b/examples/mantle-voice-banking-skills/data/source/README.md
@@ -1,0 +1,7 @@
+# Fixture data — entirely fictional
+
+Every person, company, account, and event in this directory is **invented for
+this project**. Nothing corresponds to a real person, a real business, or any
+real conversation. Do not replace these records with real customer data — the
+repo-wide `fictional-data` lint rejects real institutions and unreserved email
+domains, and this catalog is public.

--- a/examples/mantle-voice-banking-skills/skills/banking_faq/references/README.md
+++ b/examples/mantle-voice-banking-skills/skills/banking_faq/references/README.md
@@ -1,0 +1,7 @@
+# Fixture data — entirely fictional
+
+Every person, company, account, and event in this directory is **invented for
+this project**. Nothing corresponds to a real person, a real business, or any
+real conversation. Do not replace these records with real customer data — the
+repo-wide `fictional-data` lint rejects real institutions and unreserved email
+domains, and this catalog is public.

--- a/examples/mantle-voice-car-purchase-skills/data/source/README.md
+++ b/examples/mantle-voice-car-purchase-skills/data/source/README.md
@@ -1,0 +1,7 @@
+# Fixture data — entirely fictional
+
+Every person, company, account, and event in this directory is **invented for
+this project**. Nothing corresponds to a real person, a real business, or any
+real conversation. Do not replace these records with real customer data — the
+repo-wide `fictional-data` lint rejects real institutions and unreserved email
+domains, and this catalog is public.

--- a/examples/mantle-voice-car-purchase-skills/skills/car_faq/references/README.md
+++ b/examples/mantle-voice-car-purchase-skills/skills/car_faq/references/README.md
@@ -1,0 +1,7 @@
+# Fixture data — entirely fictional
+
+Every person, company, account, and event in this directory is **invented for
+this project**. Nothing corresponds to a real person, a real business, or any
+real conversation. Do not replace these records with real customer data — the
+repo-wide `fictional-data` lint rejects real institutions and unreserved email
+domains, and this catalog is public.

--- a/examples/mantle-voice-insurance-skills/data/source/README.md
+++ b/examples/mantle-voice-insurance-skills/data/source/README.md
@@ -1,0 +1,7 @@
+# Fixture data — entirely fictional
+
+Every person, company, account, and event in this directory is **invented for
+this project**. Nothing corresponds to a real person, a real business, or any
+real conversation. Do not replace these records with real customer data — the
+repo-wide `fictional-data` lint rejects real institutions and unreserved email
+domains, and this catalog is public.

--- a/examples/mantle-voice-insurance-skills/skills/insurance_faq/references/README.md
+++ b/examples/mantle-voice-insurance-skills/skills/insurance_faq/references/README.md
@@ -1,0 +1,7 @@
+# Fixture data — entirely fictional
+
+Every person, company, account, and event in this directory is **invented for
+this project**. Nothing corresponds to a real person, a real business, or any
+real conversation. Do not replace these records with real customer data — the
+repo-wide `fictional-data` lint rejects real institutions and unreserved email
+domains, and this catalog is public.

--- a/examples/mantle-voice-telco-skills/data/source/README.md
+++ b/examples/mantle-voice-telco-skills/data/source/README.md
@@ -1,0 +1,7 @@
+# Fixture data — entirely fictional
+
+Every person, company, account, and event in this directory is **invented for
+this project**. Nothing corresponds to a real person, a real business, or any
+real conversation. Do not replace these records with real customer data — the
+repo-wide `fictional-data` lint rejects real institutions and unreserved email
+domains, and this catalog is public.

--- a/examples/mantle-voice-telco-skills/skills/telco_faq/references/README.md
+++ b/examples/mantle-voice-telco-skills/skills/telco_faq/references/README.md
@@ -1,0 +1,7 @@
+# Fixture data — entirely fictional
+
+Every person, company, account, and event in this directory is **invented for
+this project**. Nothing corresponds to a real person, a real business, or any
+real conversation. Do not replace these records with real customer data — the
+repo-wide `fictional-data` lint rejects real institutions and unreserved email
+domains, and this catalog is public.

--- a/heroes/wave-01-mantle/projects/README.md
+++ b/heroes/wave-01-mantle/projects/README.md
@@ -9,6 +9,9 @@ heroes/wave-01-mantle/projects/<your-handle>-<project-slug>/
   pyproject.toml     pins the rasa-pro version you verified against
   uv.lock            committed, and matching that pin
   .env.example       no secrets, only the key names your project needs
+  data/…             FICTIONAL identities only — invented people and invented
+                     businesses, emails on example.com; the `fictional-data`
+                     lint rejects real institutions and unreserved domains
   …
 ```
 

--- a/scripts/lint_repo.py
+++ b/scripts/lint_repo.py
@@ -491,6 +491,123 @@ SECRET_PATTERNS = (
 )
 
 
+# ------------------------------------------------------------------------------
+# Fictional-data policy (operator directive, 2026-09-02)
+# ------------------------------------------------------------------------------
+# Every person, company and institution in this catalog's content and fixtures
+# must be INVENTED. This exists because the catalog's use cases are routinely
+# inspired by real field conversations about real institutions, and one leaked
+# name presented as data reads as a confidential disclosure whatever the intent.
+# The policy is doctrine; these three rules are the part a machine can hold.
+
+#: Real institutions that must never appear in catalog content. This list is
+#: the risk class that has actually come up in field discussions, not an
+#: attempt to enumerate the world — extend it when a new real name nearly
+#: ships. Vendors this catalog INTEGRATES (Rasa, OpenAI, Deepgram, HubSpot,
+#: Twilio, …) are deliberately absent: naming the product you integrate is not
+#: naming a client.
+REAL_ENTITY_RE = re.compile(
+    r"\b(BNP\s+Paribas|\bBNP\b|JPMorgan|JP\s+Morgan|JPMC|Goldman\s+Sachs"
+    r"|Morgan\s+Stanley|Bank\s+of\s+America|Merrill\s+Lynch|Wells\s+Fargo"
+    r"|Citigroup|Citibank|HSBC|Barclays|Deutsche\s+Bank|Credit\s+Suisse"
+    r"|Santander|Vanguard|BlackRock|Fidelity\s+Investments)\b",
+    re.IGNORECASE,
+)
+
+#: Email domains that are safe by construction (RFC 2606 reserved) …
+_RESERVED_EMAIL_RE = re.compile(
+    r"@(?:[\w.-]*example\.(?:com|org|net)|[\w.-]+\.(?:example|test|invalid|localhost))$",
+    re.IGNORECASE,
+)
+#: … plus domains this catalog has DECLARED fictional. Asimov-character
+#: addresses predate this rule; they are unmistakably invented but their
+#: domains are registrable, so new content should prefer example.* — these
+#: stay allowlisted rather than churning shipped fixtures.
+FICTIONAL_EMAIL_DOMAINS = frozenset(
+    {"asimovbranch.com", "trantorbranch.com", "terminusbranch.com"}
+)
+_EMAIL_RE = re.compile(r"\b[A-Za-z0-9._%+-]+@([A-Za-z0-9.-]+\.[A-Za-z]{2,})\b")
+
+#: A fixture directory must SAY it is fictional where a reader will look.
+FICTION_TOKEN_RE = re.compile(
+    r"fixture|invented|fictional|synthetic|fake|mock", re.IGNORECASE
+)
+
+
+def check_fictional_data() -> list[Finding]:
+    """Real entities never appear; fixture identities are declared invented.
+
+    Three mechanical rules:
+      1. No real-institution name anywhere in tracked catalog content.
+      2. Every email address in tracked content uses an RFC 2606 reserved
+         domain or one this file explicitly declares fictional.
+      3. Every `data/source/` and `references/` directory (outside snippet
+         mirrors) carries a README.md whose opening declares the contents
+         fictional — because 42 of the catalog's 43 fixture JSONs are arrays
+         and cannot carry a `_comment` of their own.
+    """
+    findings: list[Finding] = []
+
+    content = _tracked_files("*.md", "*.py", "*.json", "*.yml", "*.toml")
+    fixture_dirs: set[Path] = set()
+    for path in content:
+        rel = _rel(path)
+        if rel.startswith(("docs/", "scripts/", ".github/")):
+            continue  # repo tooling and policy docs may NAME the rule's targets
+        text = _read(path)
+        for lineno, line in _numbered(text):
+            m = REAL_ENTITY_RE.search(line)
+            if m:
+                findings.append(
+                    Finding(
+                        "fictional-data",
+                        rel,
+                        lineno,
+                        f"real institution {m.group(0)!r} in catalog content — "
+                        "invent a business instead (fictional-data policy)",
+                    )
+                )
+            for em in _EMAIL_RE.finditer(line):
+                domain = em.group(1).lower()
+                if _RESERVED_EMAIL_RE.search("@" + domain):
+                    continue
+                if domain in FICTIONAL_EMAIL_DOMAINS:
+                    continue
+                if domain.endswith(("github.com", "rasa.com", "astral.sh")):
+                    continue  # real project/vendor contact points, not data
+                findings.append(
+                    Finding(
+                        "fictional-data",
+                        rel,
+                        lineno,
+                        f"email on unreserved domain {domain!r} — use "
+                        "example.com/org/net or add the domain to "
+                        "FICTIONAL_EMAIL_DOMAINS with a reason",
+                    )
+                )
+        parent = path.parent
+        rel_parent = _rel(parent)
+        if "/snippets/" not in f"/{rel_parent}/" and (
+            rel_parent.endswith("data/source") or rel_parent.endswith("references")
+        ):
+            fixture_dirs.add(parent)
+
+    for directory in sorted(fixture_dirs):
+        readme = directory / "README.md"
+        head = _read(readme)[:600] if readme.is_file() else ""
+        if not FICTION_TOKEN_RE.search(head):
+            findings.append(
+                Finding(
+                    "fictional-data",
+                    _rel(directory),
+                    None,
+                    "fixture directory lacks a README.md declaring its "
+                    "contents fictional (fictional-data policy)",
+                )
+            )
+    return findings
+
+
 def check_secret_hygiene() -> list[Finding]:
     """No credentials committed, and no .env tracked."""
     findings: list[Finding] = []
@@ -1034,6 +1151,9 @@ CHECKS = {
     # Both tiers: a frozen resource still has to say who verified it and when.
     "resource-metadata": lambda p, s, e: check_resource_metadata(p + s),
     "secret-hygiene": lambda p, s, e: check_secret_hygiene(),
+    # Both tiers: a frozen resource can leak a real name as easily as a
+    # maintained one, and the reader cannot tell intent from bytes.
+    "fictional-data": lambda p, s, e: check_fictional_data(),
     "workflow-pins": lambda p, s, e: check_workflow_pins(),
     "agent-config-keys": lambda p, s, e: check_agent_config_keys(),
     "brand-terms": lambda p, s, e: check_brand_terms(),

--- a/scripts/test_tooling.py
+++ b/scripts/test_tooling.py
@@ -312,6 +312,76 @@ class TestSkillProseRules(unittest.TestCase):
         self.assertEqual([t.count(".") for t in partial], [1])
 
 
+class TestFictionalDataPolicy(unittest.TestCase):
+    """The fictional-data rules, each with the mutation that turns it red.
+
+    Operator directive 2026-09-02: every person, company and institution in
+    catalog content must be invented. These tests hold the mechanical third
+    of that policy; the doctrine lives in docs/TUTORIAL-TEMPLATE.md §5.
+    """
+
+    def test_a_real_institution_name_is_flagged(self):
+        line = "Our client BNP Paribas asked for a document workflow."
+        self.assertTrue(lint_repo.REAL_ENTITY_RE.search(line))
+
+    def test_vendor_products_are_not_flagged(self):
+        for line in (
+            "Point HUBSPOT_BASE_URL at the real HubSpot API.",
+            "Deepgram Flux for ASR, OpenAI for the judge.",
+        ):
+            self.assertIsNone(lint_repo.REAL_ENTITY_RE.search(line))
+
+    def test_reserved_and_declared_email_domains_pass(self):
+        for addr in ("dana.okafor@example.com", "bel.riose@asimovbranch.com"):
+            domain = lint_repo._EMAIL_RE.search(addr).group(1).lower()
+            ok = bool(
+                lint_repo._RESERVED_EMAIL_RE.search("@" + domain)
+            ) or domain in lint_repo.FICTIONAL_EMAIL_DOMAINS
+            self.assertTrue(ok, addr)
+
+    def test_an_unreserved_email_domain_is_flagged(self):
+        domain = lint_repo._EMAIL_RE.search("ceo@barclays-wealth.co.uk").group(1)
+        self.assertFalse(lint_repo._RESERVED_EMAIL_RE.search("@" + domain))
+        self.assertNotIn(domain.lower(), lint_repo.FICTIONAL_EMAIL_DOMAINS)
+
+    def test_fixture_readme_must_carry_a_fiction_token(self):
+        self.assertTrue(
+            lint_repo.FICTION_TOKEN_RE.search("All records here are invented.")
+        )
+        self.assertIsNone(
+            lint_repo.FICTION_TOKEN_RE.search(
+                "Records for the pilot deployment."  # the red mutation: a
+                # README that exists but never says the data is fictional
+            )
+        )
+
+    def test_the_full_check_is_clean_on_the_real_repo_and_bites_on_a_probe(self):
+        """End to end: clean now; a planted real-entity file turns it red."""
+        clean = [
+            f for f in lint_repo.check_fictional_data()
+            if f.severity == lint_repo.SEVERITY_ERROR
+        ]
+        self.assertEqual(clean, [], "\n".join(f.message for f in clean))
+        probe = lint_repo.REPO_ROOT / "examples" / "_fiction_probe.md"
+        probe.write_text("A case study with JPMorgan private bank.\n")
+        try:
+            subprocess.run(
+                ["git", "-C", str(lint_repo.REPO_ROOT), "add", str(probe)],
+                check=True, capture_output=True,
+            )
+            hits = [
+                f for f in lint_repo.check_fictional_data()
+                if "JPMorgan" in f.message
+            ]
+            self.assertTrue(hits, "planted real institution was not flagged")
+        finally:
+            subprocess.run(
+                ["git", "-C", str(lint_repo.REPO_ROOT), "rm", "-fq", "--cached", str(probe)],
+                check=True, capture_output=True,
+            )
+            probe.unlink(missing_ok=True)
+
+
 class TestLintChecksAgainstRepo(unittest.TestCase):
     """Sanity: the real repository must satisfy every check."""
 

--- a/tutorials/rasa-card-reissue-tutorial/data/source/README.md
+++ b/tutorials/rasa-card-reissue-tutorial/data/source/README.md
@@ -1,0 +1,7 @@
+# Fixture data — entirely fictional
+
+Every person, company, account, and event in this directory is **invented for
+this project**. Nothing corresponds to a real person, a real business, or any
+real conversation. Do not replace these records with real customer data — the
+repo-wide `fictional-data` lint rejects real institutions and unreserved email
+domains, and this catalog is public.

--- a/tutorials/rasa-hubspot-crm-tutorial/README.md
+++ b/tutorials/rasa-hubspot-crm-tutorial/README.md
@@ -65,7 +65,7 @@ each menu lives and what to do when a scope is missing. The short version:
 2. Scopes: `crm.objects.contacts.read`, `tickets`, `crm.objects.notes.write`
 3. Copy the token from the app's **Auth** tab into `HUBSPOT_ACCESS_TOKEN`
 4. Comment out `HUBSPOT_BASE_URL` so it falls back to `https://api.hubapi.com`
-5. `make crm-check EMAIL=you@yourcompany.com` before running the agent
+5. `make crm-check EMAIL=you@example.com` before running the agent
 
 Nothing else changes. That is the point of keeping the base URL configurable.
 

--- a/tutorials/rasa-hubspot-crm-tutorial/SETUP.md
+++ b/tutorials/rasa-hubspot-crm-tutorial/SETUP.md
@@ -134,7 +134,7 @@ Commenting out `HUBSPOT_BASE_URL` is what makes the agent talk to
 ## Step 4 — Prove the token works
 
 ```bash
-make crm-check EMAIL=you@yourcompany.com
+make crm-check EMAIL=you@example.com
 ```
 
 Use a real email that exists in your HubSpot as a contact — your own is

--- a/tutorials/rasa-hubspot-crm-tutorial/scripts/crm_check.py
+++ b/tutorials/rasa-hubspot-crm-tutorial/scripts/crm_check.py
@@ -5,7 +5,7 @@ Run this before the agent. It answers the two questions that otherwise cost an
 hour: is the token working, and does it have the right scopes?
 
     make crm-check                      # against whatever .env points at
-    make crm-check EMAIL=someone@x.com  # look up a specific contact
+    make crm-check EMAIL=someone@example.com  # look up a specific contact
 
 Each capability is probed independently, so a missing scope shows up as one
 failed row naming the scope to add, rather than as a generic 403.
@@ -106,7 +106,7 @@ async def main() -> int:
     if contact is None:
         print()
         print(f"{YELLOW}  No contact to test tickets or notes against.{RESET}")
-        print(f"{DIM}  Re-run with a real address: make crm-check EMAIL=you@yourcompany.com{RESET}")
+        print(f"{DIM}  Re-run with a real address: make crm-check EMAIL=you@example.com{RESET}")
         print()
         return 1 if failures else 0
 

--- a/tutorials/rasa-voice-agent-tutorial/data/source/README.md
+++ b/tutorials/rasa-voice-agent-tutorial/data/source/README.md
@@ -1,0 +1,7 @@
+# Fixture data — entirely fictional
+
+Every person, company, account, and event in this directory is **invented for
+this project**. Nothing corresponds to a real person, a real business, or any
+real conversation. Do not replace these records with real customer data — the
+repo-wide `fictional-data` lint rejects real institutions and unreserved email
+domains, and this catalog is public.

--- a/tutorials/rasa-voice-agent-tutorial/skills/trip_faq/references/README.md
+++ b/tutorials/rasa-voice-agent-tutorial/skills/trip_faq/references/README.md
@@ -1,0 +1,7 @@
+# Fixture data — entirely fictional
+
+Every person, company, account, and event in this directory is **invented for
+this project**. Nothing corresponds to a real person, a real business, or any
+real conversation. Do not replace these records with real customer data — the
+repo-wide `fictional-data` lint rejects real institutions and unreserved email
+domains, and this catalog is public.


### PR DESCRIPTION
Operator-directed after the #28/#29 privacy sweep came back clean: make the fictional-names policy hard bytes, not review vigilance.

Three mechanical rules in one new check (`fictional-data`), each mutation-tested: a real-institution denylist over catalog content (vendors we integrate deliberately absent — naming the product you integrate is not naming a client); RFC-2606-or-declared email domains (Asimov-character domains allowlisted with the reason, two real-ish placeholders incl. `someone@x.com` fixed); and a fictionality README per fixture dir (42/43 fixture JSONs are arrays — nowhere to put a `_comment`).

Sweep: 17 READMEs + 4 email lines. Doctrine: template §5 law + checklist + the wave-01 submission contract, where every hackathon submitter will read it before Sept 20.

Verified: planted-JPMorgan probe flagged then cleaned (in the test suite permanently); 19/19 lint checks green; test_tooling OK; root validate green. Companion site PR adds BANNED_ENTITIES to the copy gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B9TWdwx7DsdoAaNGPKvKi8