### PR TITLE
fictional-data: cover the fixture dir that merged in parallel with the gate

### DIFF
--- a/tutorials/rasa-document-artifact-tutorial/data/source/README.md
+++ b/tutorials/rasa-document-artifact-tutorial/data/source/README.md
@@ -7,3 +7,8 @@ provenance, not because any real custodian or adviser was consulted. Do not
 replace these records with real customer data — the repo-wide
 `fictional-data` lint rejects real institutions and unreserved email domains,
 and this catalog is public.
+
+`references/disclosures.json` is a third surface and a different kind: approved
+wording a document quotes verbatim, not data it computes from. It is fictional
+too, and is **not** regulatory text from any jurisdiction — do not treat it as
+compliant language for any real document.

--- a/tutorials/rasa-document-artifact-tutorial/data/source/README.md
+++ b/tutorials/rasa-document-artifact-tutorial/data/source/README.md
@@ -1,0 +1,9 @@
+# Fixture data — entirely fictional
+
+Every person, company, account, and event in this directory is **invented for
+this project**. Marged Ellis, Thornbury Wealth, and every record ID are
+fictional; the two sources exist so one document can prove multi-source
+provenance, not because any real custodian or adviser was consulted. Do not
+replace these records with real customer data — the repo-wide
+`fictional-data` lint rejects real institutions and unreserved email domains,
+and this catalog is public.


### PR DESCRIPTION
Post-merge double-check (operator-requested) found main red on the 19th check: #29 and #30 merged in parallel, so the gate's sweep never saw the document-artifact tutorial's `data/source/`. One README closes it — 19/19 checks and the full tooling suite green with this commit. This is the gate catching exactly the class it was built for, on its first day.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B9TWdwx7DsdoAaNGPKvKi8