### PR TITLE
Fix the red trunk: declare the document-artifact fixtures fictional

### DIFF
--- a/tutorials/rasa-document-artifact-tutorial/data/source/README.md
+++ b/tutorials/rasa-document-artifact-tutorial/data/source/README.md
@@ -1,0 +1,19 @@
+# Fixture data — entirely fictional
+
+Every person, company, holding, valuation, and account in this directory is
+**invented for this tutorial**. Nothing corresponds to a real person, a real
+business, a real security, or any real portfolio. Do not replace these records
+with real customer data — the repo-wide `fictional-data` lint rejects real
+institutions and unreserved email domains, and this catalog is public.
+
+Two sources sit here on purpose. The tutorial teaches that every figure in a
+generated document must trace to a source record, so it needs more than one
+record set to make provenance visible:
+
+- `factfind.json` — the client profile a document's narrative fields cite.
+- `holdings.json` — the positions its figures cite.
+
+`references/disclosures.json` is a third surface and a different kind: approved
+wording a document quotes verbatim, not data it computes from. It is fictional
+too, and is **not** regulatory text from any jurisdiction — do not treat it as
+compliant language for any real document.


### PR DESCRIPTION
**`origin/main` is currently RED.** This is the one-file fix.

## What happened

Two PRs that each passed alone are jointly red:

- **#30** added the 19th lint check — `fictional-data`, requiring every fixture directory to
  declare its contents invented.
- **#29** added `tutorials/rasa-document-artifact-tutorial/data/source/` with two fixtures and
  no README.

Neither branch could see the other. **A merge-order collision, not a defect in either PR.**

## Current trunk state

```
lint_repo.py     1 error(s), 0 warning(s); 18 check(s) clean
                 ✗ tutorials/rasa-document-artifact-tutorial/data/source
                     fixture directory lacks a README.md declaring its contents fictional

test_tooling.py  2 failures — TestFictionalDataPolicy and
                 TestLintChecksAgainstRepo.test_repo_is_clean
                 (same root cause: the trunk is not clean under the new check)

make validate    Error 1
```

## After this PR

```
✓ All 19 checks passed.
Ran 110 tests — OK (skipped=1)
✓ validate passed — repository is internally consistent.
```

## The README

Follows the existing pattern (`examples/mantle-voice-agent/data/source/README.md`) and adds what
this tutorial specifically needs:

- **why there are two sources** — the tutorial teaches that every figure must trace to a source
  record, and provenance is only visible with more than one record set;
- an explicit warning that `references/disclosures.json` is approved **wording** a document
  quotes rather than data it computes from — fictional, and **not** regulatory text from any
  jurisdiction, so nobody mistakes it for compliant language.

## Worth noting

This is the same shape the site integration surfaced an hour ago: two individually-correct
changes that are jointly red, invisible until they sit on one tree. There the guard was a
snapshot test; here it is a lint check. **Both times the gate did its job, and both times only
integration revealed it** — which is the argument for integrating rather than merging in
sequence.
